### PR TITLE
[codex] Add hidden Three.js demos page

### DIFF
--- a/react-three/src/App.js
+++ b/react-three/src/App.js
@@ -5,6 +5,7 @@ import { Bloom, EffectComposer, N8AO, TiltShift2 } from "@react-three/postproces
 import { Route, Link, useLocation } from "wouter"
 import { suspend } from "suspend-react"
 import { easing } from "maath"
+import { DemosPage } from "./DemosPage"
 
 const inter = import("@pmndrs/assets/fonts/inter_regular.woff")
 
@@ -14,6 +15,11 @@ const TurtlePage = lazy(() => import('./TurtlePage').then(m => ({ default: m.Tur
 export const App = () => {
   const [loc] = useLocation()
   const isHome = loc === "/"
+  const isDemos = loc === "/demos" || loc === "/demos/"
+
+  if (isDemos) {
+    return <DemosPage />
+  }
 
   return (
     <>

--- a/react-three/src/App.test.js
+++ b/react-three/src/App.test.js
@@ -1,0 +1,87 @@
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+import { App } from "./App"
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+jest.mock("@pmndrs/assets/fonts/inter_regular.woff", () => ({
+  __esModule: true,
+  default: "mock-font"
+}))
+
+jest.mock("@react-three/fiber", () => ({
+  Canvas: ({ children }) => <div data-testid="canvas">{children}</div>,
+  useFrame: jest.fn()
+}))
+
+jest.mock("@react-three/drei", () => ({
+  Float: ({ children }) => <div>{children}</div>,
+  Lightformer: () => <div />,
+  Text: ({ children }) => <span>{children}</span>,
+  Html: ({ children }) => <span>{children}</span>,
+  ContactShadows: () => <div />,
+  Environment: ({ children }) => <div>{children}</div>,
+  MeshTransmissionMaterial: () => <div />
+}))
+
+jest.mock("@react-three/postprocessing", () => ({
+  Bloom: () => <div />,
+  EffectComposer: ({ children }) => <div>{children}</div>,
+  N8AO: () => <div />,
+  TiltShift2: () => <div />
+}))
+
+jest.mock("wouter", () => ({
+  Link: ({ children, to, className }) => (
+    <a className={className} href={to}>{children}</a>
+  ),
+  Route: ({ children, path }) => (
+    globalThis.location.pathname === path ? <>{children}</> : null
+  ),
+  useLocation: () => [globalThis.location.pathname]
+}))
+
+jest.mock("suspend-react", () => ({
+  suspend: () => ({ default: "mock-font" })
+}))
+
+jest.mock("maath", () => ({
+  easing: { damp3: jest.fn() }
+}))
+
+describe("App demos route", () => {
+  let container
+  let root
+
+  beforeEach(() => {
+    window.history.pushState({}, "", "/demos")
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    window.history.pushState({}, "", "/")
+  })
+
+  it("renders the hidden demos page with official Three.js examples", () => {
+    act(() => root.render(<App />))
+
+    const frames = Array.from(container.querySelectorAll("iframe"))
+    const sources = frames.map((frame) => frame.getAttribute("src"))
+
+    expect(frames).toHaveLength(4)
+    expect(sources).toEqual(expect.arrayContaining([
+      "https://threejs.org/examples/webgl_buffergeometry_drawrange.html",
+      "https://threejs.org/examples/webgl_postprocessing_pixel.html",
+      "https://threejs.org/examples/css3d_mixed.html",
+      "https://threejs.org/examples/webgpu_compute_cloth.html"
+    ]))
+    expect(container.textContent).toContain("CSS3D Mixed")
+    expect(container.textContent).toContain("WebGPU Compute Cloth")
+    expect(container.querySelector(".nav")?.textContent || "").not.toContain("demos")
+  })
+})

--- a/react-three/src/DemosPage.js
+++ b/react-three/src/DemosPage.js
@@ -1,0 +1,70 @@
+const DEMO_EXAMPLES = [
+  {
+    title: "Draw Range",
+    label: "WebGL BufferGeometry",
+    url: "https://threejs.org/examples/webgl_buffergeometry_drawrange.html",
+    note: "Animated particles and line draw ranges."
+  },
+  {
+    title: "Pixel Pass",
+    label: "WebGL Postprocessing",
+    url: "https://threejs.org/examples/webgl_postprocessing_pixel.html",
+    note: "Pixelated render pass with outline controls."
+  },
+  {
+    title: "CSS3D Mixed",
+    label: "CSS and WebGL",
+    url: "https://threejs.org/examples/css3d_mixed.html",
+    note: "Layered CSS3D panels with WebGL geometry."
+  },
+  {
+    title: "WebGPU Compute Cloth",
+    label: "WebGPU",
+    url: "https://threejs.org/examples/webgpu_compute_cloth.html",
+    note: "Compute-shader cloth simulation. Requires WebGPU support."
+  }
+]
+
+export function DemosPage() {
+  return (
+    <main className="demos-page">
+      <header className="demos-header">
+        <div>
+          <p className="demos-kicker">Hidden lab</p>
+          <h1>Three.js demos</h1>
+        </div>
+        <a className="demos-home" href="/">Back to site</a>
+      </header>
+
+      <section className="demos-note" aria-label="Demo caveats">
+        <p>
+          These examples run inside cross-origin iframes from threejs.org. WebGPU
+          support depends on the browser, GPU, hardware acceleration, and origin
+          policy; unsupported browsers will show the upstream fallback.
+        </p>
+      </section>
+
+      <section className="demos-grid" aria-label="Three.js example frames">
+        {DEMO_EXAMPLES.map((demo) => (
+          <article className="demo-card" key={demo.url}>
+            <div className="demo-card-header">
+              <div>
+                <p>{demo.label}</p>
+                <h2>{demo.title}</h2>
+              </div>
+              <a href={demo.url} target="_blank" rel="noreferrer">Open</a>
+            </div>
+            <iframe
+              title={demo.title}
+              src={demo.url}
+              loading="lazy"
+              referrerPolicy="no-referrer"
+              allow="fullscreen; xr-spatial-tracking"
+            />
+            <p className="demo-note">{demo.note}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/react-three/src/styles.css
+++ b/react-three/src/styles.css
@@ -168,6 +168,113 @@ a:visited {
   text-decoration: underline;
 }
 
+.demos-page {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  overflow: auto;
+  min-height: 100%;
+  padding: 42px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(224, 224, 224, 0.92)),
+    #e0e0e0;
+  color: #080808;
+}
+
+.demos-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 0 0 24px 0;
+}
+
+.demos-kicker,
+.demo-card-header p {
+  margin: 0 0 6px 0;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+.demos-header h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 6.8rem);
+  line-height: 0.86;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.demos-home,
+.demo-card-header a {
+  margin: 0;
+  border-bottom: 1px solid currentColor;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.demos-note {
+  max-width: 840px;
+  margin: 0 0 28px 0;
+  border-left: 3px solid #2f6f8f;
+  padding: 0 0 0 16px;
+}
+
+.demos-note p,
+.demo-note {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  opacity: 0.72;
+}
+
+.demos-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  padding-bottom: 42px;
+}
+
+.demo-card {
+  min-width: 0;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 8px;
+  background: rgba(245, 245, 242, 0.82);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.demo-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px 16px 12px 16px;
+}
+
+.demo-card-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.demo-card iframe {
+  display: block;
+  width: 100%;
+  height: clamp(300px, 38vw, 540px);
+  border: 0;
+  background: #111;
+}
+
+.demo-note {
+  padding: 12px 16px 16px 16px;
+}
+
 /* Mobile responsive */
 @media (max-width: 768px) {
   .nav {
@@ -213,6 +320,24 @@ a:visited {
   .about-overlay .social-links a {
     font-size: 0.7rem;
   }
+
+  .demos-page {
+    padding: 24px 18px;
+  }
+
+  .demos-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .demos-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-card iframe {
+    height: 360px;
+  }
 }
 
 @media (max-width: 480px) {
@@ -231,5 +356,18 @@ a:visited {
     right: 15px;
     bottom: 15px;
     left: 15px;
+  }
+
+  .demos-page {
+    padding: 18px 12px;
+  }
+
+  .demo-card-header {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .demo-card iframe {
+    height: 320px;
   }
 }


### PR DESCRIPTION
## What changed

- Added a hidden `/demos` route to the React Three app.
- Embedded four official Three.js examples in iframe demo cards:
  - `webgl_buffergeometry_drawrange`
  - `webgl_postprocessing_pixel`
  - `css3d_mixed`
  - `webgpu_compute_cloth`
- Kept the page out of the public nav and avoided mounting the existing Three canvas behind it.
- Added a Jest route test for the hidden page.

Closes #6.

## Validation

`CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false`

```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/App.test.js
  App demos route
    ✓ renders the hidden demos page with official Three.js examples (234 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.204 s
Ran all test suites.
```

`mise exec node@18.17.0 -- npm run build`

```text
> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-demos/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-demos/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  523.21 kB  build/static/js/main.737d7ff8.js
  35.72 kB   build/static/js/318.03a1aa09.chunk.js
  13.02 kB   build/static/js/419.913e5443.chunk.js
  1.43 kB    build/static/js/879.adb8db85.chunk.js
  1.4 kB     build/static/css/main.f4344f29.css

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment
```

`curl -I http://127.0.0.1:3102/demos`

```text
HTTP/1.1 200 OK
Content-Length: 4018
Content-Disposition: inline; filename="index.html"
Accept-Ranges: bytes
ETag: "ae957e333872af55a98a33e4be6abc69bea5f884"
Content-Type: text/html; charset=utf-8
Vary: Accept-Encoding
Date: Tue, 30 Jun 2026 04:29:29 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

Playwright iframe check against `http://127.0.0.1:3102/demos`:

```json
{
  "heading": "Three.js demos",
  "frameSources": [
    "https://threejs.org/examples/webgl_buffergeometry_drawrange.html",
    "https://threejs.org/examples/webgl_postprocessing_pixel.html",
    "https://threejs.org/examples/css3d_mixed.html",
    "https://threejs.org/examples/webgpu_compute_cloth.html"
  ],
  "navText": null,
  "expectedPresent": [
    true,
    true,
    true,
    true
  ]
}
```

Official example URL checks:

```text
webgl_buffergeometry_drawrange 200
webgl_postprocessing_pixel 200
css3d_mixed 200
webgpu_compute_cloth 200
```

## Notes

- WebGPU support still depends on the user browser/device and may show the upstream fallback in unsupported environments.
- The build warning is pre-existing dependency sourcemap noise from `@mediapipe/tasks-vision`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated demos page for Three.js examples, accessible at `/demos` and `/demos/`.
  * The page shows demo cards with titles, notes, external links, and embedded previews.
  * Added responsive styling so the demos layout works well on smaller screens.

* **Tests**
  * Added coverage for the new demos route to verify the page content and embedded examples render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->