### PR TITLE
Improve about page performance

### DIFF
--- a/react-three/package.json
+++ b/react-three/package.json
@@ -31,7 +31,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "perf:rights": "node scripts/profile-rights.mjs",
+    "perf:route": "node scripts/profile-rights.mjs",
+    "perf:rights": "node scripts/profile-rights.mjs --url http://127.0.0.1:3101/rights",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },

--- a/react-three/scripts/profile-rights.mjs
+++ b/react-three/scripts/profile-rights.mjs
@@ -2,15 +2,15 @@
 
 import { chromium } from "playwright"
 
-const DEFAULT_URL = "http://127.0.0.1:3101/rights"
+const DEFAULT_URL = "http://127.0.0.1:3101/"
 const DEFAULT_DURATION_MS = 5000
 const DEFAULT_TIMEOUT_MS = 15000
 const DEFAULT_CHANNEL = "chrome"
 
 function printHelp() {
-  console.log(`Usage: npm run perf:rights -- [options]
+  console.log(`Usage: npm run perf:route -- [options]
 
-Profiles the React Three /rights route in Chrome with Playwright.
+Profiles a React Three route in Chrome with Playwright.
 
 Options:
   --url <url>          Page URL to profile. Default: ${DEFAULT_URL}
@@ -21,16 +21,34 @@ Options:
                        Default: ${DEFAULT_CHANNEL}
   --headed             Run Chrome headed instead of headless.
   --json               Print only JSON.
+  --max-frame-p95 <ms> Fail when frame p95 exceeds this value.
+  --max-long-task-total <ms>
+                       Fail when total long-task time exceeds this value.
+  --max-console-warnings <count>
+                       Fail when warning/error console messages exceed this value.
   --help               Show this help.
 `)
 }
 
 function readOption(args, name, fallback) {
-  const eq = args.find((arg) => arg.startsWith(`${name}=`))
-  if (eq) return eq.slice(name.length + 1)
-  const index = args.indexOf(name)
-  if (index !== -1 && args[index + 1]) return args[index + 1]
+  for (let index = args.length - 1; index >= 0; index -= 1) {
+    const arg = args[index]
+    if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1)
+    if (arg === name && args[index + 1]) return args[index + 1]
+  }
   return fallback
+}
+
+function readOptionalNumber(args, name) {
+  const value = readOption(args, name, null)
+  if (value === null) return null
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number`)
+  }
+
+  return parsed
 }
 
 function parseArgs(argv) {
@@ -56,7 +74,12 @@ function parseArgs(argv) {
     timeout,
     channel: readOption(argv, "--channel", DEFAULT_CHANNEL),
     headed: argv.includes("--headed"),
-    json: argv.includes("--json")
+    json: argv.includes("--json"),
+    thresholds: {
+      maxFrameP95Ms: readOptionalNumber(argv, "--max-frame-p95"),
+      maxLongTaskTotalMs: readOptionalNumber(argv, "--max-long-task-total"),
+      maxConsoleWarnings: readOptionalNumber(argv, "--max-console-warnings")
+    }
   }
 }
 
@@ -76,8 +99,48 @@ function delta(after, before, name) {
   return (after[name] || 0) - (before[name] || 0)
 }
 
+function evaluateThresholds(report) {
+  const checks = []
+  const { thresholds } = report.options
+
+  if (thresholds.maxFrameP95Ms !== null) {
+    checks.push({
+      name: "frame p95",
+      actual: report.frames.p95Ms,
+      max: thresholds.maxFrameP95Ms,
+      unit: "ms"
+    })
+  }
+
+  if (thresholds.maxLongTaskTotalMs !== null) {
+    checks.push({
+      name: "long task total",
+      actual: report.longTasks.totalDurationMs,
+      max: thresholds.maxLongTaskTotalMs,
+      unit: "ms"
+    })
+  }
+
+  if (thresholds.maxConsoleWarnings !== null) {
+    checks.push({
+      name: "console warnings/errors",
+      actual: report.console.warningOrErrorCount,
+      max: thresholds.maxConsoleWarnings,
+      unit: ""
+    })
+  }
+
+  return {
+    passed: checks.every((check) => check.actual <= check.max),
+    checks: checks.map((check) => ({
+      ...check,
+      passed: check.actual <= check.max
+    }))
+  }
+}
+
 function printHuman(report) {
-  console.log(`Rights page performance profile
+  console.log(`Route performance profile
 URL: ${report.url}
 Status: ${report.status}
 Readiness: domcontentloaded + canvas selector; networkidle intentionally skipped
@@ -129,6 +192,15 @@ Console:
 Page errors:       ${report.pageErrors.length}
 Request failures:  ${report.requestFailures.length}`)
 
+  if (report.thresholds.checks.length) {
+    console.log("\nThresholds:")
+    for (const check of report.thresholds.checks) {
+      const actual = check.unit === "ms" ? formatMs(check.actual) : check.actual
+      const max = check.unit === "ms" ? formatMs(check.max) : check.max
+      console.log(`  ${check.passed ? "pass" : "fail"} ${check.name}: ${actual} <= ${max}`)
+    }
+  }
+
   if (report.console.messages.length) {
     console.log("\nFirst console messages:")
     for (const message of report.console.messages.slice(0, 8)) {
@@ -145,7 +217,7 @@ Request failures:  ${report.requestFailures.length}`)
 }
 
 async function collectInPageMetrics(duration) {
-  return window.__profileRightsCollect(duration)
+  return window.__profileRouteCollect(duration)
 }
 
 async function main() {
@@ -217,7 +289,7 @@ async function main() {
     })
 
     await page.evaluate(() => {
-      window.__profileRightsCollect = async (duration) => {
+      window.__profileRouteCollect = async (duration) => {
         const longTasks = []
         let longTaskSupported = false
         let longTaskObserver = null
@@ -355,11 +427,17 @@ async function main() {
         nodes: afterMetrics.Nodes || 0
       }
     }
+    report.thresholds = evaluateThresholds(report)
+    report.status = report.thresholds.passed ? "ok" : "threshold-failed"
 
     if (options.json) {
       console.log(JSON.stringify(report, null, 2))
     } else {
       printHuman(report)
+    }
+
+    if (!report.thresholds.passed) {
+      process.exitCode = 1
     }
   } finally {
     await browser.close()
@@ -367,6 +445,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(`perf:rights failed: ${error.message}`)
+  console.error(`perf:route failed: ${error.message}`)
   process.exit(1)
 })

--- a/react-three/src/App.js
+++ b/react-three/src/App.js
@@ -14,7 +14,7 @@ const TurtlePage = lazy(() => import('./TurtlePage').then(m => ({ default: m.Tur
 
 export const App = () => {
   const [loc] = useLocation()
-  const isHome = loc === "/"
+  const isAbout = loc === "/" || loc === "/about" || loc === "/about/"
   const isDemos = loc === "/demos" || loc === "/demos/"
 
   if (isDemos) {
@@ -23,7 +23,7 @@ export const App = () => {
 
   return (
     <>
-      {isHome ? (
+      {isAbout ? (
         <Suspense fallback={<div className="loading">Loading...</div>}>
           <TurtlePage />
         </Suspense>
@@ -31,12 +31,12 @@ export const App = () => {
         <MainCanvas />
       )}
       <div className="nav">
-        <Link to="/" className={loc === "/" ? "active" : ""}>about</Link>
+        <Link to="/" className={isAbout ? "active" : ""}>about</Link>
         <Link to="/rights" className={loc === "/rights" ? "active" : ""}>rights</Link>
         <Link to="/activism" className={loc === "/activism" ? "active" : ""}>activism</Link>
         <Link to="/charity" className={loc === "/charity" ? "active" : ""}>charity</Link>
       </div>
-      {isHome ? <AboutOverlay /> : <CauseInfo />}
+      {isAbout ? <AboutOverlay /> : <CauseInfo />}
     </>
   )
 }

--- a/react-three/src/App.test.js
+++ b/react-three/src/App.test.js
@@ -32,6 +32,10 @@ jest.mock("@react-three/postprocessing", () => ({
   TiltShift2: () => <div />
 }))
 
+jest.mock("./TurtlePage", () => ({
+  TurtleCanvas: () => <div data-testid="turtle-canvas" />
+}))
+
 jest.mock("wouter", () => ({
   Link: ({ children, to, className }) => (
     <a className={className} href={to}>{children}</a>
@@ -50,6 +54,33 @@ jest.mock("maath", () => ({
   easing: { damp3: jest.fn() }
 }))
 
+describe("App about route", () => {
+  let container
+  let root
+
+  beforeEach(() => {
+    window.history.pushState({}, "", "/about")
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    window.history.pushState({}, "", "/")
+  })
+
+  it("renders the about page at /about", async () => {
+    await act(async () => root.render(<App />))
+
+    expect(container.textContent).toContain("Data-driven founder")
+    expect(container.textContent).toContain("Subconscious AI")
+    expect(container.textContent).not.toContain("Non-Human Rights")
+    expect(container.querySelector(".nav a.active")?.textContent).toBe("about")
+  })
+})
+
 describe("App demos route", () => {
   let container
   let root
@@ -67,8 +98,8 @@ describe("App demos route", () => {
     window.history.pushState({}, "", "/")
   })
 
-  it("renders the hidden demos page with official Three.js examples", () => {
-    act(() => root.render(<App />))
+  it("renders the hidden demos page with official Three.js examples", async () => {
+    await act(async () => root.render(<App />))
 
     const frames = Array.from(container.querySelectorAll("iframe"))
     const sources = frames.map((frame) => frame.getAttribute("src"))

--- a/react-three/src/TurtlePage.js
+++ b/react-three/src/TurtlePage.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { Canvas, useFrame } from "@react-three/fiber"
-import { Float, Lightformer, Environment, MeshTransmissionMaterial } from "@react-three/drei"
-import { useGLTF, useAnimations, Instance, Instances, CameraControls, RandomizedLight, AccumulativeShadows } from "@react-three/drei"
+import { Float } from "@react-three/drei"
+import { useGLTF, useAnimations, Instance, Instances, CameraControls } from "@react-three/drei"
 
 // Bubble configuration for turtle aquarium
 const spheres = [
@@ -26,33 +26,27 @@ const TURTLE_MODEL = '/turtle-draco.glb'
 // Turtle aquarium canvas
 export function TurtleCanvas() {
   return (
-    <Canvas shadows camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}>
+    <Canvas
+      dpr={[1, 1]}
+      frameloop="demand"
+      gl={{ antialias: false, powerPreference: "high-performance" }}
+      camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}
+    >
       <color attach="background" args={['#e0e0e0']} />
+      <ambientLight intensity={0.45} />
+      <directionalLight position={[-5, 10, -5]} intensity={1.5} />
       <Aquarium position={[0, 0.25, 0]}>
         <Float rotationIntensity={0.3} floatIntensity={2} speed={2}>
           <Turtle position={[0, -0.5, -1]} rotation={[0, Math.PI, 0]} scale={17} />
         </Float>
         <Instances renderOrder={-1000}>
-          <sphereGeometry args={[1, 64, 64]} />
+          <sphereGeometry args={[1, 24, 16]} />
           <meshBasicMaterial depthTest={false} />
           {spheres.map(([scale, color, speed, position], index) => (
             <TurtleSphere key={index} scale={scale} color={color} speed={speed} position={position} />
           ))}
         </Instances>
       </Aquarium>
-      <AccumulativeShadows temporal frames={60} color="lightblue" colorBlend={2} opacity={0.7} scale={60} position={[0, -5, 0]}>
-        <RandomizedLight amount={8} radius={15} ambient={0.5} intensity={1} position={[-5, 10, -5]} size={20} />
-      </AccumulativeShadows>
-      <Environment resolution={1024}>
-        <group rotation={[-Math.PI / 3, 0, 0]}>
-          <Lightformer intensity={4} rotation-x={Math.PI / 2} position={[0, 5, -9]} scale={[10, 10, 1]} />
-          {[2, 0, 2, 0, 2, 0, 2, 0].map((x, i) => (
-            <Lightformer key={i} form="circle" intensity={4} rotation={[Math.PI / 2, 0, 0]} position={[x, 4, i * 4]} scale={[4, 1, 1]} />
-          ))}
-          <Lightformer intensity={2} rotation-y={Math.PI / 2} position={[-5, 1, -1]} scale={[50, 2, 1]} />
-          <Lightformer intensity={2} rotation-y={-Math.PI / 2} position={[10, 1, 0]} scale={[50, 2, 1]} />
-        </group>
-      </Environment>
       <CameraControls truckSpeed={0} dollySpeed={0} minPolarAngle={0} maxPolarAngle={Math.PI / 2} />
     </Canvas>
   )
@@ -63,19 +57,14 @@ function Aquarium({ children, ...props }) {
   const { nodes } = useGLTF(AQUARIUM_MODEL)
   return (
     <group {...props} dispose={null}>
-      <mesh castShadow scale={[0.61 * 6, 0.8 * 6, 1 * 6]} geometry={nodes.Cube.geometry}>
-        <MeshTransmissionMaterial
-          backside
-          samples={4}
-          thickness={3}
-          chromaticAberration={0.025}
-          anisotropy={0.1}
-          distortion={0.1}
-          distortionScale={0.1}
-          temporalDistortion={0.2}
-          iridescence={1}
-          iridescenceIOR={1}
-          iridescenceThicknessRange={[0, 1400]}
+      <mesh scale={[0.61 * 6, 0.8 * 6, 1 * 6]} geometry={nodes.Cube.geometry}>
+        <meshStandardMaterial
+          color="#dff7ff"
+          transparent
+          opacity={0.22}
+          roughness={0.06}
+          metalness={0}
+          depthWrite={false}
         />
       </mesh>
       <group>{children}</group>


### PR DESCRIPTION
## Summary
- Makes `/about` render the same About experience as `/`, instead of falling through to the non-home canvas/default rights copy.
- Generalizes the Playwright profiler as `npm run perf:route` with threshold flags while keeping `perf:rights` as a compatibility alias.
- Reduces the About/Turtle scene startup and runtime cost by using demand-based rendering, fixed DPR, direct lighting, lower bubble geometry, and cheap transparent aquarium material instead of temporal shadows/environment/transmission passes.

Closes #9

## Exit criterion

```bash
cd react-three && npm run perf:route -- --url http://127.0.0.1:3101/about --max-frame-p95 250 --max-long-task-total 1000 --max-console-warnings 4
```

Output:

```text
> router-transitions@1.0.0 perf:route
> node scripts/profile-rights.mjs --url http://127.0.0.1:3101/about --max-frame-p95 250 --max-long-task-total 1000 --max-console-warnings 4

Route performance profile
URL: http://127.0.0.1:3101/about
Status: ok
Readiness: domcontentloaded + canvas selector; networkidle intentionally skipped
Sample window: 5000ms

Navigation:
  domContentLoaded: 232.7ms
  loadEvent:        336.5ms
  responseEnd:      8.2ms

Frame timing:
  frames:     301
  avg:        16.7ms (60.0 fps)
  min:        16.6ms
  p50/p95/p99:16.7ms / 16.8ms / 16.8ms
  max:        16.8ms
  >16.7ms:    87
  >33.3ms:    0
  >50ms:      0

Long tasks:
  supported: true
  count:     2
  total:     690.0ms
  max:       555.0ms

WebGL:
  available: true
  renderer:  ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)
  vendor:    Google Inc. (Google)
  buffer:    1440x900
  css size:  1440x900
  ratio:     1.00
  antialias: false
  max texture/renderbuffer: 8192 / 8192
  extensions: 29

Chrome/CDP:
  task:        1016.3ms
  script:      347.1ms
  layout:      23.0ms
  recalcStyle: 7.4ms
  nodes:       87

Console:
  warnings/errors: 3
  total messages:  3

Page errors:       0
Request failures:  0

Thresholds:
  pass frame p95: 16.8ms <= 250.0ms
  pass long task total: 690.0ms <= 1000.0ms
  pass console warnings/errors: 3 <= 4

First console messages:
  [warning] [.WebGL-0x2444000e9400]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [warning] [.WebGL-0x2444000e9400]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [warning] [.WebGL-0x2444000e9400]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
```

## Additional verification

Baseline before the About scene optimization:

```text
Frame timing p95: 2466.6ms
Long tasks total: 12496.0ms
```

Root alias check:

```text
npm run perf:route -- --url http://127.0.0.1:3101/ --max-frame-p95 250 --max-long-task-total 1000 --max-console-warnings 4
Status: ok
frame p95: 16.8ms
long task total: 875.0ms
console warnings/errors: 4
```

Rights profiler compatibility:

```text
npm run perf:rights -- --duration 1000 --json
exit 0; produced JSON status "ok" for http://127.0.0.1:3101/rights.
```

Tests:

```text
CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false
PASS src/App.test.js
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

Build:

```text
mise exec node@18.17.0 -- npm run build
Compiled with warnings.
Warning: missing @mediapipe/tasks-vision/vision_bundle_mjs.js.map source map.
The build folder is ready to be deployed.
```

Visual/canvas check:

```json
[
  {
    "name": "desktop",
    "imageWidth": 1440,
    "imageHeight": 900,
    "uniqueSamples": 3,
    "hasAboutText": true,
    "hasCanvas": true,
    "canvasCssWidth": 1440,
    "canvasCssHeight": 900
  },
  {
    "name": "mobile",
    "imageWidth": 390,
    "imageHeight": 844,
    "uniqueSamples": 5,
    "hasAboutText": true,
    "hasCanvas": true,
    "canvasCssWidth": 390,
    "canvasCssHeight": 844
  }
]
```

```text
git diff --check
exit 0
```

## Notes
- This keeps the About scene visually recognizable, but the scene is now static/demand-rendered instead of continuously animating under the overlay. That removes the visible choppiness on the first About page.
- Absolute GPU numbers are from headless Chrome/SwiftShader in WSL; the before/after delta is the relevant local signal.
- Port 3000 was not used.
