### PR TITLE
Restore automatic turtle animation

### DIFF
--- a/react-three/src/TurtlePage.js
+++ b/react-three/src/TurtlePage.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Canvas, useFrame } from "@react-three/fiber"
+import { Canvas, useFrame, useThree } from "@react-three/fiber"
 import { Float } from "@react-three/drei"
 import { useGLTF, useAnimations, Instance, Instances, CameraControls } from "@react-three/drei"
 
@@ -33,6 +33,7 @@ export function TurtleCanvas() {
       camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}
     >
       <color attach="background" args={['#e0e0e0']} />
+      <AutoInvalidate fps={2} />
       <ambientLight intensity={0.45} />
       <directionalLight position={[-5, 10, -5]} intensity={1.5} />
       <Aquarium position={[0, 0.25, 0]}>
@@ -50,6 +51,20 @@ export function TurtleCanvas() {
       <CameraControls truckSpeed={0} dollySpeed={0} minPolarAngle={0} maxPolarAngle={Math.PI / 2} />
     </Canvas>
   )
+}
+
+export function AutoInvalidate({ fps = 8 }) {
+  const three = useThree()
+  const invalidate = typeof three === 'function' ? three : three?.invalidate
+
+  useEffect(() => {
+    if (typeof invalidate !== 'function') return undefined
+
+    const intervalId = setInterval(invalidate, 1000 / fps)
+    return () => clearInterval(intervalId)
+  }, [fps, invalidate])
+
+  return null
 }
 
 // Aquarium glass container

--- a/react-three/src/TurtlePage.test.js
+++ b/react-three/src/TurtlePage.test.js
@@ -1,0 +1,79 @@
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+let canvasProps
+const mockInvalidate = jest.fn()
+let mockIntervalCallback
+
+jest.mock("@react-three/fiber", () => ({
+  Canvas: ({ children, ...props }) => {
+    canvasProps = props
+    return <div data-testid="turtle-canvas" />
+  },
+  useFrame: jest.fn(),
+  useThree: jest.fn()
+}))
+
+jest.mock("@react-three/drei", () => ({
+  Float: ({ children }) => <div>{children}</div>,
+  useGLTF: jest.fn(() => ({
+    nodes: { Cube: { geometry: {} } },
+    scene: { rotation: { z: 0 } },
+    animations: []
+  })),
+  useAnimations: jest.fn(() => ({
+    actions: {},
+    mixer: { timeScale: 1 }
+  })),
+  Instance: () => <div />,
+  Instances: ({ children }) => <div>{children}</div>,
+  CameraControls: () => <div />
+}))
+
+describe("TurtleCanvas", () => {
+  const { useThree } = require("@react-three/fiber")
+  const { TurtleCanvas, AutoInvalidate } = require("./TurtlePage")
+  let container
+  let root
+
+  beforeEach(() => {
+    canvasProps = undefined
+    mockInvalidate.mockClear()
+    useThree.mockReturnValue({ invalidate: mockInvalidate })
+    mockIntervalCallback = undefined
+    global.setInterval = jest.fn((callback) => {
+      mockIntervalCallback = callback
+      return 1
+    })
+    global.clearInterval = jest.fn()
+    window.setInterval = global.setInterval
+    window.clearInterval = global.clearInterval
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("keeps the optimized demand frame loop", () => {
+    act(() => root.render(<TurtleCanvas />))
+
+    expect(canvasProps.frameloop).toBe("demand")
+  })
+
+  it("invalidates frames automatically so the turtle animates without a click", async () => {
+    await act(async () => root.render(<AutoInvalidate fps={8} />))
+
+    expect(global.setInterval).toHaveBeenCalledWith(expect.any(Function), 125)
+    expect(mockInvalidate).not.toHaveBeenCalled()
+
+    act(() => mockIntervalCallback())
+    expect(mockInvalidate).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes #12

## Summary
- Kept the optimized React Three Fiber `frameloop="demand"` path on the About turtle canvas.
- Added a low-frequency `AutoInvalidate` tick so the turtle advances automatically on load without requiring a click.
- Added a regression test for demand rendering plus automatic invalidation.

## Exit criterion output
Command:

```bash
cd react-three && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false && mise exec node@18.17.0 -- npm run build && mise exec node@18.17.0 -- npm run perf:route -- --url http://127.0.0.1:3101/about --max-frame-p95 250 --max-long-task-total 2500 --max-console-warnings 4
```

Output:

```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/TurtlePage.test.js
PASS src/App.test.js

Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.453 s
Ran all test suites.

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-turtle-animation/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-turtle-animation/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  522.85 kB (+1 B)  build/static/js/main.d9b4f368.js
  33.31 kB          build/static/js/771.e2f0600b.chunk.js
  13.02 kB          build/static/js/419.913e5443.chunk.js
  1.4 kB            build/static/css/main.f4344f29.css
  1.32 kB           build/static/js/879.bcf13011.chunk.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

Route performance profile
URL: http://127.0.0.1:3101/about
Status: ok
Readiness: domcontentloaded + canvas selector; networkidle intentionally skipped
Sample window: 5000ms

Navigation:
  domContentLoaded: 306.3ms
  loadEvent:        481.2ms
  responseEnd:      15.4ms

Frame timing:
  frames:     289
  avg:        17.4ms (57.6 fps)
  min:        16.6ms
  p50/p95/p99:16.7ms / 16.8ms / 33.4ms
  max:        50.0ms
  >16.7ms:    78
  >33.3ms:    8
  >50ms:      0

Long tasks:
  supported: true
  count:     4
  total:     866.0ms
  max:       579.0ms

WebGL:
  available: true
  renderer:  ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)
  vendor:    Google Inc. (Google)
  buffer:    1440x900
  css size:  1440x900
  ratio:     1.00
  antialias: false
  max texture/renderbuffer: 8192 / 8192
  extensions: 29

Chrome/CDP:
  task:        1646.0ms
  script:      442.7ms
  layout:      23.5ms
  recalcStyle: 5.8ms
  nodes:       87

Console:
  warnings/errors: 4
  total messages:  4

Page errors:       0
Request failures:  0

Thresholds:
  pass frame p95: 16.8ms <= 250.0ms
  pass long task total: 866.0ms <= 2500.0ms
  pass console warnings/errors: 4 <= 4

First console messages:
  [warning] [.WebGL-0x3a0c000eb800]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [warning] [.WebGL-0x3a0c000eb800]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [warning] [.WebGL-0x3a0c000eb800]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [warning] [.WebGL-0x3a0c000eb800]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels (this message will no longer repeat)
```

## No-click browser check

```json
{
  "changed": 1655,
  "sampled": 6868,
  "changedRatio": 0.24097262667443214,
  "hasAboutText": true,
  "canvasCount": 1
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic canvas refresh at a configurable frame rate to keep 3D scenes updating smoothly.
  * Default refresh rate is set to 8 frames per second, with the option to adjust it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->