### PR TITLE
Improve Rights page runtime performance

### DIFF
--- a/react-three/src/App.js
+++ b/react-three/src/App.js
@@ -1,10 +1,8 @@
 import { lazy, Suspense, useState, useEffect } from 'react'
-import { Canvas, useFrame } from "@react-three/fiber"
-import { Float, Lightformer, Text, Html, ContactShadows, Environment, MeshTransmissionMaterial } from "@react-three/drei"
-import { Bloom, EffectComposer, N8AO, TiltShift2 } from "@react-three/postprocessing"
+import { Canvas } from "@react-three/fiber"
+import { Text, Html } from "@react-three/drei"
 import { Route, Link, useLocation } from "wouter"
 import { suspend } from "suspend-react"
-import { easing } from "maath"
 import { DemosPage } from "./DemosPage"
 
 const inter = import("@pmndrs/assets/fonts/inter_regular.woff")
@@ -55,72 +53,52 @@ function MainCanvas() {
     <Canvas
       eventSource={document.getElementById("root")}
       eventPrefix="client"
-      shadows
-      dpr={isMobile ? [1, 1.5] : [1, 2]}
+      frameloop="demand"
+      gl={{ antialias: false, powerPreference: "high-performance" }}
+      dpr={[1, 1]}
       camera={{ position: [0, 0, 20], fov: 50 }}
     >
       <color attach="background" args={["#e0e0e0"]} />
-      <spotLight position={[20, 20, 10]} penumbra={1} castShadow angle={0.2} />
+      <ambientLight intensity={0.8} />
+      <directionalLight position={[8, 10, 8]} intensity={1.8} />
       <Status position={[0, 0, isMobile ? -50 : -10]} isMobile={isMobile} />
-      <Float floatIntensity={2}>
-        <Route path="/rights">
-          <Knot isMobile={isMobile} />
-        </Route>
-        <Route path="/activism">
-          <ShapeTorus isMobile={isMobile} />
-        </Route>
-        <Route path="/charity">
-          <Dodecahedron isMobile={isMobile} />
-        </Route>
-      </Float>
-      <ContactShadows scale={100} position={[0, -7.5, 0]} blur={1} far={100} opacity={0.85} />
-      <Environment resolution={isMobile ? 128 : 256}>
-        <Lightformer intensity={8} position={[10, 5, 0]} scale={[10, 50, 1]} onUpdate={(self) => self.lookAt(0, 0, 0)} />
-        <Lightformer intensity={2} position={[-10, 5, 0]} scale={[10, 50, 1]} />
-        <Lightformer intensity={4} position={[0, 10, 0]} scale={[50, 10, 1]} rotation-x={Math.PI / 2} />
-      </Environment>
-      <EffectComposer disableNormalPass>
-        <N8AO aoRadius={1} intensity={isMobile ? 1 : 2} />
-        <Bloom mipmapBlur luminanceThreshold={0.8} intensity={isMobile ? 1 : 2} levels={isMobile ? 4 : 8} />
-        <TiltShift2 blur={0.2} />
-      </EffectComposer>
-      <Rig />
+      <Route path="/rights">
+        <Knot isMobile={isMobile} />
+      </Route>
+      <Route path="/activism">
+        <ShapeTorus isMobile={isMobile} />
+      </Route>
+      <Route path="/charity">
+        <Dodecahedron isMobile={isMobile} />
+      </Route>
     </Canvas>
   )
 }
 
-function Rig() {
-  useFrame((state, delta) => {
-    easing.damp3(
-      state.camera.position,
-      [Math.sin(-state.pointer.x) * 5, state.pointer.y * 3.5, 15 + Math.cos(state.pointer.x) * 10],
-      0.4,
-      delta,
-    )
-    state.camera.lookAt(0, 0, 0)
-  })
-}
-
 const ShapeTorus = ({ isMobile, ...props }) => (
-  <mesh receiveShadow castShadow {...props}>
-    <torusGeometry args={isMobile ? [4, 1.2, 64, 32] : [4, 1.2, 128, 64]} />
-    <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} samples={isMobile ? 2 : 4} />
+  <mesh {...props}>
+    <torusGeometry args={isMobile ? [4, 1.2, 48, 24] : [4, 1.2, 96, 32]} />
+    <CauseMaterial />
   </mesh>
 )
 
 const Knot = ({ isMobile, ...props }) => (
-  <mesh receiveShadow castShadow {...props}>
-    <torusKnotGeometry args={isMobile ? [3, 1, 128, 16] : [3, 1, 256, 32]} />
-    <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} samples={isMobile ? 2 : 4} />
+  <mesh {...props}>
+    <torusKnotGeometry args={isMobile ? [3, 1, 96, 12] : [3, 1, 160, 18]} />
+    <CauseMaterial />
   </mesh>
 )
 
 const Dodecahedron = ({ isMobile, ...props }) => (
-  <mesh receiveShadow castShadow {...props}>
+  <mesh {...props}>
     <dodecahedronGeometry args={[4, 0]} />
-    <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} samples={isMobile ? 2 : 4} />
+    <CauseMaterial />
   </mesh>
 )
+
+function CauseMaterial() {
+  return <meshStandardMaterial color="#f0f0f0" roughness={0.35} metalness={0.12} />
+}
 
 function Status({ isMobile, ...props }) {
   const [loc] = useLocation()

--- a/react-three/src/App.test.js
+++ b/react-three/src/App.test.js
@@ -5,14 +5,40 @@ import { App } from "./App"
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
+let canvasProps
+let mockEffectComposer
+let mockMeshTransmissionMaterial
+let mockUseFrame
+let consoleErrorSpy
+const originalConsoleError = console.error
+
+beforeEach(() => {
+  canvasProps = undefined
+  mockEffectComposer = jest.fn()
+  mockMeshTransmissionMaterial = jest.fn()
+  mockUseFrame = jest.fn()
+  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation((message, ...args) => {
+    const text = [message, ...args].join(" ")
+    if (text.includes("unrecognized") || text.includes("incorrect casing") || text.includes("does not recognize")) return
+    originalConsoleError(message, ...args)
+  })
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
 jest.mock("@pmndrs/assets/fonts/inter_regular.woff", () => ({
   __esModule: true,
   default: "mock-font"
 }))
 
 jest.mock("@react-three/fiber", () => ({
-  Canvas: ({ children }) => <div data-testid="canvas">{children}</div>,
-  useFrame: jest.fn()
+  Canvas: ({ children, ...props }) => {
+    canvasProps = props
+    return <div data-testid="canvas">{children}</div>
+  },
+  useFrame: (...args) => mockUseFrame(...args)
 }))
 
 jest.mock("@react-three/drei", () => ({
@@ -22,12 +48,18 @@ jest.mock("@react-three/drei", () => ({
   Html: ({ children }) => <span>{children}</span>,
   ContactShadows: () => <div />,
   Environment: ({ children }) => <div>{children}</div>,
-  MeshTransmissionMaterial: () => <div />
+  MeshTransmissionMaterial: (...args) => {
+    mockMeshTransmissionMaterial(...args)
+    return <div />
+  }
 }))
 
 jest.mock("@react-three/postprocessing", () => ({
   Bloom: () => <div />,
-  EffectComposer: ({ children }) => <div>{children}</div>,
+  EffectComposer: ({ children }) => {
+    mockEffectComposer()
+    return <div>{children}</div>
+  },
   N8AO: () => <div />,
   TiltShift2: () => <div />
 }))
@@ -114,5 +146,33 @@ describe("App demos route", () => {
     expect(container.textContent).toContain("CSS3D Mixed")
     expect(container.textContent).toContain("WebGPU Compute Cloth")
     expect(container.querySelector(".nav")?.textContent || "").not.toContain("demos")
+  })
+})
+
+describe("App rights route performance", () => {
+  let container
+  let root
+
+  beforeEach(() => {
+    window.history.pushState({}, "", "/rights")
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    window.history.pushState({}, "", "/")
+  })
+
+  it("keeps the rights scene static and avoids expensive postprocessing", async () => {
+    await act(async () => root.render(<App />))
+
+    expect(canvasProps.frameloop).toBe("demand")
+    expect(canvasProps.dpr).toEqual([1, 1])
+    expect(mockUseFrame).not.toHaveBeenCalled()
+    expect(mockEffectComposer).not.toHaveBeenCalled()
+    expect(mockMeshTransmissionMaterial).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Job
Improve the `/rights` page runtime performance without changing its visual product direction.

Closes #17

## What changed
- Switched the non-about 3D scene to demand rendering at DPR 1.
- Removed the continuous camera rig, floating animation, postprocessing stack, contact shadows, environment lights, and transmission material from the shared cause scene.
- Kept the abstract 3D cause shapes, using a lightweight standard material and lower geometry detail.
- Added a regression test for the `/rights` runtime path.

## Baseline
Before this change, `/rights` failed the profiler with frame p95 `1383.3ms`, long-task total `6482.0ms`, and only `4` frames in the 5s sample window.

## Exit criterion
`cd react-three && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false && mise exec node@18.17.0 -- npm run build && mise exec node@18.17.0 -- npm run perf:route -- --url http://127.0.0.1:3101/rights --max-frame-p95 80 --max-long-task-total 2500 --max-console-warnings 4`

Raw output:
```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/TurtlePage.test.js
PASS src/App.test.js

Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.074 s
Ran all test suites.

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-rights-perf/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-rights-perf/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  299.27 kB  build/static/js/main.c8f6e609.js
  31.51 kB   build/static/js/319.0137b3f6.chunk.js
  13.02 kB   build/static/js/419.913e5443.chunk.js
  1.59 kB    build/static/css/main.4f505304.css
  567 B      build/static/js/879.bc103af7.chunk.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment


> router-transitions@1.0.0 perf:route
> node scripts/profile-rights.mjs --url http://127.0.0.1:3101/rights --max-frame-p95 80 --max-long-task-total 2500 --max-console-warnings 4

Route performance profile
URL: http://127.0.0.1:3101/rights
Status: ok
Readiness: domcontentloaded + canvas selector; networkidle intentionally skipped
Sample window: 5000ms

Navigation:
  domContentLoaded: 139.1ms
  loadEvent:        201.9ms
  responseEnd:      4.6ms

Frame timing:
  frames:     300
  avg:        16.7ms (60.0 fps)
  min:        16.5ms
  p50/p95/p99:16.7ms / 16.8ms / 16.8ms
  max:        16.8ms
  >16.7ms:    81
  >33.3ms:    0
  >50ms:      0

Long tasks:
  supported: true
  count:     3
  total:     376.0ms
  max:       204.0ms

WebGL:
  available: true
  renderer:  ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)
  vendor:    Google Inc. (Google)
  buffer:    1440x900
  css size:  1440x900
  ratio:     1.00
  antialias: false
  max texture/renderbuffer: 8192 / 8192
  extensions: 29

Chrome/CDP:
  task:        587.8ms
  script:      203.4ms
  layout:      8.9ms
  recalcStyle: 5.4ms
  nodes:       72

Console:
  warnings/errors: 4
  total messages:  5

Page errors:       0
Request failures:  0

Thresholds:
  pass frame p95: 16.8ms <= 80.0ms
  pass long task total: 376.0ms <= 2500.0ms
  pass console warnings/errors: 4 <= 4

First console messages:
  [warning] [.WebGL-0x342c000ed600]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [warning] [.WebGL-0x342c000e6400]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [warning] [.WebGL-0x342c000e6400]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels
  [debug] unsupported GSUB table LookupType 6 format 2
  [warning] [.WebGL-0x342c000e6400]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels (this message will no longer repeat)
```

## Out of scope
- Did not redesign the About/demos pages.
- Did not use port 3000.
- Did not modify the profiler.
