### PR TITLE
Revert Rights page visual simplification

### DIFF
--- a/react-three/src/App.js
+++ b/react-three/src/App.js
@@ -1,8 +1,10 @@
 import { lazy, Suspense, useState, useEffect } from 'react'
-import { Canvas } from "@react-three/fiber"
-import { Text, Html } from "@react-three/drei"
+import { Canvas, useFrame } from "@react-three/fiber"
+import { Float, Lightformer, Text, Html, ContactShadows, Environment, MeshTransmissionMaterial } from "@react-three/drei"
+import { Bloom, EffectComposer, N8AO, TiltShift2 } from "@react-three/postprocessing"
 import { Route, Link, useLocation } from "wouter"
 import { suspend } from "suspend-react"
+import { easing } from "maath"
 import { DemosPage } from "./DemosPage"
 
 const inter = import("@pmndrs/assets/fonts/inter_regular.woff")
@@ -53,52 +55,72 @@ function MainCanvas() {
     <Canvas
       eventSource={document.getElementById("root")}
       eventPrefix="client"
-      frameloop="demand"
-      gl={{ antialias: false, powerPreference: "high-performance" }}
-      dpr={[1, 1]}
+      shadows
+      dpr={isMobile ? [1, 1.5] : [1, 2]}
       camera={{ position: [0, 0, 20], fov: 50 }}
     >
       <color attach="background" args={["#e0e0e0"]} />
-      <ambientLight intensity={0.8} />
-      <directionalLight position={[8, 10, 8]} intensity={1.8} />
+      <spotLight position={[20, 20, 10]} penumbra={1} castShadow angle={0.2} />
       <Status position={[0, 0, isMobile ? -50 : -10]} isMobile={isMobile} />
-      <Route path="/rights">
-        <Knot isMobile={isMobile} />
-      </Route>
-      <Route path="/activism">
-        <ShapeTorus isMobile={isMobile} />
-      </Route>
-      <Route path="/charity">
-        <Dodecahedron isMobile={isMobile} />
-      </Route>
+      <Float floatIntensity={2}>
+        <Route path="/rights">
+          <Knot isMobile={isMobile} />
+        </Route>
+        <Route path="/activism">
+          <ShapeTorus isMobile={isMobile} />
+        </Route>
+        <Route path="/charity">
+          <Dodecahedron isMobile={isMobile} />
+        </Route>
+      </Float>
+      <ContactShadows scale={100} position={[0, -7.5, 0]} blur={1} far={100} opacity={0.85} />
+      <Environment resolution={isMobile ? 128 : 256}>
+        <Lightformer intensity={8} position={[10, 5, 0]} scale={[10, 50, 1]} onUpdate={(self) => self.lookAt(0, 0, 0)} />
+        <Lightformer intensity={2} position={[-10, 5, 0]} scale={[10, 50, 1]} />
+        <Lightformer intensity={4} position={[0, 10, 0]} scale={[50, 10, 1]} rotation-x={Math.PI / 2} />
+      </Environment>
+      <EffectComposer disableNormalPass>
+        <N8AO aoRadius={1} intensity={isMobile ? 1 : 2} />
+        <Bloom mipmapBlur luminanceThreshold={0.8} intensity={isMobile ? 1 : 2} levels={isMobile ? 4 : 8} />
+        <TiltShift2 blur={0.2} />
+      </EffectComposer>
+      <Rig />
     </Canvas>
   )
 }
 
+function Rig() {
+  useFrame((state, delta) => {
+    easing.damp3(
+      state.camera.position,
+      [Math.sin(-state.pointer.x) * 5, state.pointer.y * 3.5, 15 + Math.cos(state.pointer.x) * 10],
+      0.4,
+      delta,
+    )
+    state.camera.lookAt(0, 0, 0)
+  })
+}
+
 const ShapeTorus = ({ isMobile, ...props }) => (
-  <mesh {...props}>
-    <torusGeometry args={isMobile ? [4, 1.2, 48, 24] : [4, 1.2, 96, 32]} />
-    <CauseMaterial />
+  <mesh receiveShadow castShadow {...props}>
+    <torusGeometry args={isMobile ? [4, 1.2, 64, 32] : [4, 1.2, 128, 64]} />
+    <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} samples={isMobile ? 2 : 4} />
   </mesh>
 )
 
 const Knot = ({ isMobile, ...props }) => (
-  <mesh {...props}>
-    <torusKnotGeometry args={isMobile ? [3, 1, 96, 12] : [3, 1, 160, 18]} />
-    <CauseMaterial />
+  <mesh receiveShadow castShadow {...props}>
+    <torusKnotGeometry args={isMobile ? [3, 1, 128, 16] : [3, 1, 256, 32]} />
+    <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} samples={isMobile ? 2 : 4} />
   </mesh>
 )
 
 const Dodecahedron = ({ isMobile, ...props }) => (
-  <mesh {...props}>
+  <mesh receiveShadow castShadow {...props}>
     <dodecahedronGeometry args={[4, 0]} />
-    <CauseMaterial />
+    <MeshTransmissionMaterial backside backsideThickness={5} thickness={2} samples={isMobile ? 2 : 4} />
   </mesh>
 )
-
-function CauseMaterial() {
-  return <meshStandardMaterial color="#f0f0f0" roughness={0.35} metalness={0.12} />
-}
 
 function Status({ isMobile, ...props }) {
   const [loc] = useLocation()

--- a/react-three/src/App.test.js
+++ b/react-three/src/App.test.js
@@ -5,40 +5,14 @@ import { App } from "./App"
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
-let canvasProps
-let mockEffectComposer
-let mockMeshTransmissionMaterial
-let mockUseFrame
-let consoleErrorSpy
-const originalConsoleError = console.error
-
-beforeEach(() => {
-  canvasProps = undefined
-  mockEffectComposer = jest.fn()
-  mockMeshTransmissionMaterial = jest.fn()
-  mockUseFrame = jest.fn()
-  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation((message, ...args) => {
-    const text = [message, ...args].join(" ")
-    if (text.includes("unrecognized") || text.includes("incorrect casing") || text.includes("does not recognize")) return
-    originalConsoleError(message, ...args)
-  })
-})
-
-afterEach(() => {
-  consoleErrorSpy.mockRestore()
-})
-
 jest.mock("@pmndrs/assets/fonts/inter_regular.woff", () => ({
   __esModule: true,
   default: "mock-font"
 }))
 
 jest.mock("@react-three/fiber", () => ({
-  Canvas: ({ children, ...props }) => {
-    canvasProps = props
-    return <div data-testid="canvas">{children}</div>
-  },
-  useFrame: (...args) => mockUseFrame(...args)
+  Canvas: ({ children }) => <div data-testid="canvas">{children}</div>,
+  useFrame: jest.fn()
 }))
 
 jest.mock("@react-three/drei", () => ({
@@ -48,18 +22,12 @@ jest.mock("@react-three/drei", () => ({
   Html: ({ children }) => <span>{children}</span>,
   ContactShadows: () => <div />,
   Environment: ({ children }) => <div>{children}</div>,
-  MeshTransmissionMaterial: (...args) => {
-    mockMeshTransmissionMaterial(...args)
-    return <div />
-  }
+  MeshTransmissionMaterial: () => <div />
 }))
 
 jest.mock("@react-three/postprocessing", () => ({
   Bloom: () => <div />,
-  EffectComposer: ({ children }) => {
-    mockEffectComposer()
-    return <div>{children}</div>
-  },
+  EffectComposer: ({ children }) => <div>{children}</div>,
   N8AO: () => <div />,
   TiltShift2: () => <div />
 }))
@@ -146,33 +114,5 @@ describe("App demos route", () => {
     expect(container.textContent).toContain("CSS3D Mixed")
     expect(container.textContent).toContain("WebGPU Compute Cloth")
     expect(container.querySelector(".nav")?.textContent || "").not.toContain("demos")
-  })
-})
-
-describe("App rights route performance", () => {
-  let container
-  let root
-
-  beforeEach(() => {
-    window.history.pushState({}, "", "/rights")
-    container = document.createElement("div")
-    document.body.appendChild(container)
-    root = createRoot(container)
-  })
-
-  afterEach(() => {
-    act(() => root.unmount())
-    container.remove()
-    window.history.pushState({}, "", "/")
-  })
-
-  it("keeps the rights scene static and avoids expensive postprocessing", async () => {
-    await act(async () => root.render(<App />))
-
-    expect(canvasProps.frameloop).toBe("demand")
-    expect(canvasProps.dpr).toEqual([1, 1])
-    expect(mockUseFrame).not.toHaveBeenCalled()
-    expect(mockEffectComposer).not.toHaveBeenCalled()
-    expect(mockMeshTransmissionMaterial).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Job
Restore the rich `/rights` page visual treatment removed by PR #19.

Closes #20

## What changed
- Reverts `b951a09` / PR #19.
- Restores `MeshTransmissionMaterial`, `EffectComposer`, `Float`, `Environment`, `ContactShadows`, and the pointer camera rig for the cause pages.
- Removes the static-scene performance regression test that enforced the visually flattened version.

## What went wrong
The previous fix optimized by deleting the expensive visual systems instead of preserving the visual direction and finding a lower-cost way to keep them. It made the profiler green but stripped the transparent/transmission look and motion that made the page work.

## Exit criterion
`git grep -q "MeshTransmissionMaterial" -- react-three/src/App.js && git grep -q "EffectComposer" -- react-three/src/App.js && cd react-three && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false && mise exec node@18.17.0 -- npm run build`

Raw output:
```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/TurtlePage.test.js
PASS src/App.test.js

Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.375 s
Ran all test suites.

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-revert-rights/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-revert-rights/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  522.69 kB  build/static/js/main.ae488f2d.js
  31.49 kB   build/static/js/974.880e8ecd.chunk.js
  13.02 kB   build/static/js/419.913e5443.chunk.js
  1.59 kB    build/static/css/main.4f505304.css
  568 B      build/static/js/879.8180e6dc.chunk.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment
```

## Out of scope
- Did not attempt a new performance optimization.
- Did not change `/about` in this PR; that is #21.
- Did not use port 3000.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the 3D scene with richer lighting, shadows, and post-processing effects for a more polished visual experience.
  * Added smoother camera motion that follows pointer movement, making the scene feel more dynamic.
  * Upgraded route-based 3D objects with higher-detail meshes and more realistic material effects.

* **Bug Fixes**
  * Enhanced mobile rendering behavior by adjusting visual quality settings based on device type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->