### PR TITLE
Revert About turtle visual simplification

### DIFF
--- a/react-three/scripts/check-turtle-smoothness.mjs
+++ b/react-three/scripts/check-turtle-smoothness.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+
+import { chromium } from "playwright"
+
+const DEFAULT_URL = "http://127.0.0.1:3101/about"
+const DEFAULT_DURATION_MS = 5000
+const DEFAULT_TIMEOUT_MS = 15000
+const DEFAULT_CHANNEL = "chrome"
+
+function printHelp() {
+  console.log(`Usage: node scripts/check-turtle-smoothness.mjs [options]
+
+Checks that the About page turtle animates without click/drag interaction.
+
+Options:
+  --url <url>                  Page URL to check. Default: ${DEFAULT_URL}
+  --duration <ms>              Autoplay sample window. Default: ${DEFAULT_DURATION_MS}
+  --timeout <ms>               Navigation/canvas timeout. Default: ${DEFAULT_TIMEOUT_MS}
+  --channel <name>             Chromium channel, or "bundled". Default: ${DEFAULT_CHANNEL}
+  --headed                     Run Chrome headed instead of headless.
+  --min-changed-ratio <ratio>  Minimum screenshot pixel-change ratio.
+  --min-active-frames <count>  Minimum WebGL render frames during the sample.
+  --max-frame-gap-ms <ms>      Maximum allowed p95 gap between render frames.
+  --json                       Print only JSON.
+  --help                       Show this help.
+`)
+}
+
+function readOption(args, name, fallback) {
+  for (let index = args.length - 1; index >= 0; index -= 1) {
+    const arg = args[index]
+    if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1)
+    if (arg === name && args[index + 1]) return args[index + 1]
+  }
+  return fallback
+}
+
+function readNumber(args, name, fallback, { allowZero = true } = {}) {
+  const value = readOption(args, name, fallback)
+  const parsed = Number(value)
+
+  if (!Number.isFinite(parsed) || (allowZero ? parsed < 0 : parsed <= 0)) {
+    throw new Error(`${name} must be a ${allowZero ? "non-negative" : "positive"} number`)
+  }
+
+  return parsed
+}
+
+function parseArgs(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) return { help: true }
+
+  return {
+    help: false,
+    url: readOption(argv, "--url", DEFAULT_URL),
+    duration: readNumber(argv, "--duration", DEFAULT_DURATION_MS, { allowZero: false }),
+    timeout: readNumber(argv, "--timeout", DEFAULT_TIMEOUT_MS, { allowZero: false }),
+    channel: readOption(argv, "--channel", DEFAULT_CHANNEL),
+    headed: argv.includes("--headed"),
+    json: argv.includes("--json"),
+    thresholds: {
+      minChangedRatio: readNumber(argv, "--min-changed-ratio", 0.01),
+      minActiveFrames: readNumber(argv, "--min-active-frames", 1),
+      maxFrameGapMs: readNumber(argv, "--max-frame-gap-ms", 250)
+    }
+  }
+}
+
+function toDataUrl(buffer) {
+  return `data:image/png;base64,${buffer.toString("base64")}`
+}
+
+function groupRenderFrames(times) {
+  const frames = []
+
+  for (const time of times) {
+    const last = frames[frames.length - 1]
+
+    if (!last || time - last.last > 10) {
+      frames.push({ first: time, last: time, drawCalls: 1 })
+    } else {
+      last.last = time
+      last.drawCalls += 1
+    }
+  }
+
+  return frames
+}
+
+function percentile(values, amount) {
+  const sorted = values.slice().sort((a, b) => a - b)
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * amount))] || 0
+}
+
+function summarizeFrames(times) {
+  const frames = groupRenderFrames(times)
+  const starts = frames.map((frame) => frame.first)
+  const gaps = starts.slice(1).map((time, index) => time - starts[index])
+  const avgGap = gaps.reduce((sum, gap) => sum + gap, 0) / Math.max(1, gaps.length)
+
+  return {
+    drawCalls: times.length,
+    renderFrames: frames.length,
+    avgGapMs: avgGap,
+    p95GapMs: percentile(gaps, 0.95),
+    maxGapMs: gaps.length ? Math.max(...gaps) : 0
+  }
+}
+
+function evaluateThresholds(report) {
+  const checks = [
+    {
+      name: "changed ratio",
+      actual: report.changedRatio,
+      min: report.options.thresholds.minChangedRatio,
+      passed: report.changedRatio >= report.options.thresholds.minChangedRatio
+    },
+    {
+      name: "active frames",
+      actual: report.frames.renderFrames,
+      min: report.options.thresholds.minActiveFrames,
+      passed: report.frames.renderFrames >= report.options.thresholds.minActiveFrames
+    },
+    {
+      name: "frame gap p95",
+      actual: report.frames.p95GapMs,
+      max: report.options.thresholds.maxFrameGapMs,
+      passed: report.frames.p95GapMs <= report.options.thresholds.maxFrameGapMs
+    }
+  ]
+
+  return {
+    passed: checks.every((check) => check.passed),
+    checks
+  }
+}
+
+function formatNumber(value, digits = 3) {
+  return Number(value || 0).toFixed(digits)
+}
+
+function printHuman(report) {
+  console.log(`Turtle smoothness check
+URL: ${report.url}
+Status: ${report.status}
+Sample window: ${report.options.duration}ms
+
+Motion:
+  changed pixels: ${report.changed} / ${report.sampled}
+  changed ratio:  ${formatNumber(report.changedRatio, 4)}
+
+Render cadence:
+  draw calls:      ${report.frames.drawCalls}
+  render frames:   ${report.frames.renderFrames}
+  avg gap:         ${formatNumber(report.frames.avgGapMs, 1)}ms
+  p95 gap:         ${formatNumber(report.frames.p95GapMs, 1)}ms
+  max gap:         ${formatNumber(report.frames.maxGapMs, 1)}ms
+
+DOM:
+  about text:      ${report.hasAboutText}
+  canvas count:    ${report.canvasCount}
+
+Thresholds:`)
+
+  for (const check of report.thresholds.checks) {
+    if ("min" in check) {
+      console.log(`  ${check.passed ? "pass" : "fail"} ${check.name}: ${formatNumber(check.actual, 4)} >= ${formatNumber(check.min, 4)}`)
+    } else {
+      console.log(`  ${check.passed ? "pass" : "fail"} ${check.name}: ${formatNumber(check.actual, 1)}ms <= ${formatNumber(check.max, 1)}ms`)
+    }
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    printHelp()
+    return
+  }
+
+  const launchOptions = {
+    headless: !options.headed,
+    args: ["--enable-unsafe-webgpu", "--enable-unsafe-swiftshader"]
+  }
+
+  if (options.channel !== "bundled") launchOptions.channel = options.channel
+
+  const browser = await chromium.launch(launchOptions)
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1
+  })
+
+  try {
+    await page.addInitScript(() => {
+      window.__turtleDrawTimes = []
+
+      for (const name of ["WebGLRenderingContext", "WebGL2RenderingContext"]) {
+        const Context = window[name]
+        if (!Context) continue
+
+        for (const method of ["drawArrays", "drawElements", "drawArraysInstanced", "drawElementsInstanced"]) {
+          const original = Context.prototype[method]
+          if (typeof original !== "function") continue
+
+          Context.prototype[method] = function (...args) {
+            window.__turtleDrawTimes.push(performance.now())
+            return original.apply(this, args)
+          }
+        }
+      }
+    })
+
+    await page.goto(options.url, {
+      waitUntil: "domcontentloaded",
+      timeout: options.timeout
+    })
+
+    await page.waitForSelector("canvas", { timeout: options.timeout })
+    await page.waitForTimeout(1500)
+    await page.evaluate(() => { window.__turtleDrawTimes = [] })
+
+    const first = await page.screenshot({ fullPage: false })
+    await page.waitForTimeout(options.duration)
+    const second = await page.screenshot({ fullPage: false })
+    const frameTimes = await page.evaluate(() => window.__turtleDrawTimes.slice())
+
+    const motion = await page.evaluate(async ({ firstUrl, secondUrl }) => {
+      async function load(url) {
+        const image = new Image()
+        image.src = url
+        await image.decode()
+
+        const canvas = document.createElement("canvas")
+        canvas.width = image.naturalWidth
+        canvas.height = image.naturalHeight
+
+        const context = canvas.getContext("2d")
+        context.drawImage(image, 0, 0)
+
+        return { context, width: canvas.width, height: canvas.height }
+      }
+
+      const a = await load(firstUrl)
+      const b = await load(secondUrl)
+      const left = Math.floor(a.width * 0.22)
+      const top = Math.floor(a.height * 0.18)
+      const right = Math.floor(a.width * 0.78)
+      const bottom = Math.floor(a.height * 0.78)
+      let changed = 0
+      let sampled = 0
+
+      for (let y = top; y < bottom; y += 8) {
+        for (let x = left; x < right; x += 8) {
+          const p1 = a.context.getImageData(x, y, 1, 1).data
+          const p2 = b.context.getImageData(x, y, 1, 1).data
+          const delta = Math.abs(p1[0] - p2[0]) + Math.abs(p1[1] - p2[1]) + Math.abs(p1[2] - p2[2]) + Math.abs(p1[3] - p2[3])
+
+          sampled += 1
+          if (delta > 18) changed += 1
+        }
+      }
+
+      return {
+        changed,
+        sampled,
+        changedRatio: changed / sampled,
+        hasAboutText: document.body.innerText.includes("Data-driven founder"),
+        canvasCount: document.querySelectorAll("canvas").length
+      }
+    }, {
+      firstUrl: toDataUrl(first),
+      secondUrl: toDataUrl(second)
+    })
+
+    const report = {
+      status: "ok",
+      url: page.url(),
+      options,
+      ...motion,
+      frames: summarizeFrames(frameTimes)
+    }
+
+    report.thresholds = evaluateThresholds(report)
+    report.status = report.thresholds.passed && report.hasAboutText && report.canvasCount === 1 ? "ok" : "threshold-failed"
+
+    if (options.json) console.log(JSON.stringify(report, null, 2))
+    else printHuman(report)
+
+    if (report.status !== "ok") process.exitCode = 1
+  } finally {
+    await browser.close()
+  }
+}
+
+main().catch((error) => {
+  console.error(`check-turtle-smoothness failed: ${error.message}`)
+  process.exit(1)
+})

--- a/react-three/src/TurtlePage.js
+++ b/react-three/src/TurtlePage.js
@@ -1,31 +1,110 @@
-import { Canvas } from "@react-three/fiber"
-import { useGLTF, CameraControls } from "@react-three/drei"
+import { useEffect } from 'react'
+import { Canvas, useFrame, useThree } from "@react-three/fiber"
+import { Float } from "@react-three/drei"
+import { useGLTF, useAnimations, Instance, Instances, CameraControls } from "@react-three/drei"
+
+// Bubble configuration for turtle aquarium
+const spheres = [
+  [1, 'orange', 0.05, [-4, -1, -1]],
+  [0.75, 'hotpink', 0.1, [-4, 2, -2]],
+  [1.25, 'aquamarine', 0.2, [4, -3, 2]],
+  [1.5, 'lightblue', 0.3, [-4, -2, -3]],
+  [2, 'pink', 0.3, [-4, 2, -4]],
+  [2, 'skyblue', 0.3, [-4, 2, -4]],
+  [1.5, 'orange', 0.05, [-4, -1, -1]],
+  [2, 'hotpink', 0.1, [-4, 2, -2]],
+  [1.5, 'aquamarine', 0.2, [4, -3, 2]],
+  [1.25, 'lightblue', 0.3, [-4, -2, -3]],
+  [1, 'pink', 0.3, [-4, 2, -4]],
+  [1, 'skyblue', 0.3, [-4, 2, -4]]
+]
 
 // GLB models (local files in public folder)
+const AQUARIUM_MODEL = '/shapes-transformed.glb'
 const TURTLE_MODEL = '/turtle-draco.glb'
 
 // Turtle aquarium canvas
 export function TurtleCanvas() {
   return (
-    <div className="turtle-stage" aria-hidden="true">
-      <Canvas
-        className="turtle-canvas"
-        dpr={[1, 1]}
-        frameloop="demand"
-        gl={{ alpha: true, antialias: false, powerPreference: "high-performance" }}
-        camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}
-      >
-        <ambientLight intensity={0.45} />
-        <directionalLight position={[-5, 10, -5]} intensity={1.5} />
-        <Turtle position={[0, -0.5, -1]} rotation={[0, Math.PI, 0]} scale={55} />
-        <CameraControls truckSpeed={0} dollySpeed={0} minPolarAngle={0} maxPolarAngle={Math.PI / 2} />
-      </Canvas>
-    </div>
+    <Canvas
+      dpr={[1, 1]}
+      frameloop="demand"
+      gl={{ antialias: false, powerPreference: "high-performance" }}
+      camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}
+    >
+      <color attach="background" args={['#e0e0e0']} />
+      <AutoInvalidate fps={12} />
+      <ambientLight intensity={0.45} />
+      <directionalLight position={[-5, 10, -5]} intensity={1.5} />
+      <Aquarium position={[0, 0.25, 0]}>
+        <Float rotationIntensity={0.3} floatIntensity={2} speed={2}>
+          <Turtle position={[0, -0.5, -1]} rotation={[0, Math.PI, 0]} scale={17} />
+        </Float>
+        <Instances renderOrder={-1000}>
+          <sphereGeometry args={[1, 24, 16]} />
+          <meshBasicMaterial depthTest={false} />
+          {spheres.map(([scale, color, speed, position], index) => (
+            <TurtleSphere key={index} scale={scale} color={color} speed={speed} position={position} />
+          ))}
+        </Instances>
+      </Aquarium>
+      <CameraControls truckSpeed={0} dollySpeed={0} minPolarAngle={0} maxPolarAngle={Math.PI / 2} />
+    </Canvas>
   )
 }
 
-// Turtle model by DigitalLife3D, CC-BY-NC-4.0.
+export function AutoInvalidate({ fps = 8 }) {
+  const three = useThree()
+  const invalidate = typeof three === 'function' ? three : three?.invalidate
+
+  useEffect(() => {
+    if (typeof invalidate !== 'function') return undefined
+
+    invalidate()
+    const intervalId = setInterval(invalidate, 1000 / fps)
+    return () => clearInterval(intervalId)
+  }, [fps, invalidate])
+
+  return null
+}
+
+// Aquarium glass container
+function Aquarium({ children, ...props }) {
+  const { nodes } = useGLTF(AQUARIUM_MODEL)
+  return (
+    <group {...props} dispose={null}>
+      <mesh scale={[0.61 * 6, 0.8 * 6, 1 * 6]} geometry={nodes.Cube.geometry}>
+        <meshStandardMaterial
+          color="#dff7ff"
+          transparent
+          opacity={0.22}
+          roughness={0.06}
+          metalness={0}
+          depthWrite={false}
+        />
+      </mesh>
+      <group>{children}</group>
+    </group>
+  )
+}
+
+// Floating bubble for aquarium
+function TurtleSphere({ position, scale = 1, speed = 0.1, color = 'white' }) {
+  return (
+    <Float rotationIntensity={40} floatIntensity={20} speed={speed / 2}>
+      <Instance position={position} scale={scale} color={color} />
+    </Float>
+  )
+}
+
+// Animated swimming turtle (model by DigitalLife3D, CC-BY-NC-4.0)
 function Turtle(props) {
-  const { scene } = useGLTF(TURTLE_MODEL)
+  const { scene, animations } = useGLTF(TURTLE_MODEL)
+  const { actions, mixer } = useAnimations(animations, scene)
+  useEffect(() => {
+    mixer.timeScale = 0.5
+    actions['Swim Cycle']?.play()
+  }, [actions, mixer])
+  useFrame((state) => (scene.rotation.z = Math.sin(state.clock.elapsedTime / 4) / 4))
   return <primitive object={scene} {...props} />
 }

--- a/react-three/src/TurtlePage.test.js
+++ b/react-three/src/TurtlePage.test.js
@@ -5,12 +5,9 @@ import { createRoot } from "react-dom/client"
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
 let canvasProps
-let hasAutoInvalidate
-let mockUseGLTF
-let mockUseAnimations
-let mockUseFrame
-let consoleErrorSpy
-const originalConsoleError = console.error
+let autoInvalidateProps
+const mockInvalidate = jest.fn()
+let mockIntervalCallback
 
 jest.mock("@react-three/fiber", () => ({
   Canvas: ({ children, ...props }) => {
@@ -18,43 +15,49 @@ jest.mock("@react-three/fiber", () => ({
     const autoInvalidate = React.Children.toArray(children).find((child) => child.type?.name === "AutoInvalidate")
 
     canvasProps = props
-    hasAutoInvalidate = Boolean(autoInvalidate)
+    autoInvalidateProps = autoInvalidate?.props
 
-    const renderedChildren = React.Children.toArray(children).filter((child) => typeof child.type === "function")
-
-    return <div data-testid="turtle-canvas">{renderedChildren}</div>
+    return <div data-testid="turtle-canvas" />
   },
-  useFrame: (...args) => mockUseFrame(...args)
+  useFrame: jest.fn(),
+  useThree: jest.fn()
 }))
 
 jest.mock("@react-three/drei", () => ({
-  useGLTF: (...args) => mockUseGLTF(...args),
-  useAnimations: (...args) => mockUseAnimations(...args),
+  Float: ({ children }) => <div>{children}</div>,
+  useGLTF: jest.fn(() => ({
+    nodes: { Cube: { geometry: {} } },
+    scene: { rotation: { z: 0 } },
+    animations: []
+  })),
+  useAnimations: jest.fn(() => ({
+    actions: {},
+    mixer: { timeScale: 1 }
+  })),
+  Instance: () => <div />,
+  Instances: ({ children }) => <div>{children}</div>,
   CameraControls: () => <div />
 }))
 
 describe("TurtleCanvas", () => {
-  const { TurtleCanvas } = require("./TurtlePage")
+  const { useThree } = require("@react-three/fiber")
+  const { TurtleCanvas, AutoInvalidate } = require("./TurtlePage")
   let container
   let root
 
   beforeEach(() => {
     canvasProps = undefined
-    hasAutoInvalidate = undefined
-    mockUseGLTF = jest.fn(() => ({
-      scene: { position: { y: 0 }, rotation: { y: 0, z: 0 } },
-      animations: []
-    }))
-    mockUseAnimations = jest.fn(() => ({
-      actions: {},
-      mixer: { timeScale: 1 }
-    }))
-    mockUseFrame = jest.fn()
-    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation((message, ...args) => {
-      const text = [message, ...args].join(" ")
-      if (text.includes("primitive") && text.includes("unrecognized")) return
-      originalConsoleError(message, ...args)
+    autoInvalidateProps = undefined
+    mockInvalidate.mockClear()
+    useThree.mockReturnValue({ invalidate: mockInvalidate })
+    mockIntervalCallback = undefined
+    global.setInterval = jest.fn((callback) => {
+      mockIntervalCallback = callback
+      return 1
     })
+    global.clearInterval = jest.fn()
+    window.setInterval = global.setInterval
+    window.clearInterval = global.clearInterval
     container = document.createElement("div")
     document.body.appendChild(container)
     root = createRoot(container)
@@ -62,17 +65,28 @@ describe("TurtleCanvas", () => {
 
   afterEach(() => {
     act(() => root.unmount())
-    consoleErrorSpy.mockRestore()
     container.remove()
   })
 
-  it("uses a static WebGL render with CSS-driven turtle motion", () => {
+  it("keeps the optimized demand frame loop", () => {
     act(() => root.render(<TurtleCanvas />))
 
     expect(canvasProps.frameloop).toBe("demand")
-    expect(canvasProps.className).toBe("turtle-canvas")
-    expect(hasAutoInvalidate).toBe(false)
-    expect(mockUseFrame).not.toHaveBeenCalled()
-    expect(mockUseAnimations).not.toHaveBeenCalled()
+  })
+
+  it("uses a smooth automatic render cadence on the page", () => {
+    act(() => root.render(<TurtleCanvas />))
+
+    expect(autoInvalidateProps.fps).toBeGreaterThanOrEqual(12)
+  })
+
+  it("invalidates frames automatically so the turtle animates without a click", async () => {
+    await act(async () => root.render(<AutoInvalidate fps={8} />))
+
+    expect(global.setInterval).toHaveBeenCalledWith(expect.any(Function), 125)
+    expect(mockInvalidate).toHaveBeenCalledTimes(1)
+
+    act(() => mockIntervalCallback())
+    expect(mockInvalidate).toHaveBeenCalledTimes(2)
   })
 })

--- a/react-three/src/styles.css
+++ b/react-three/src/styles.css
@@ -29,35 +29,6 @@ body {
   opacity: 0.5;
 }
 
-.turtle-stage {
-  position: absolute;
-  top: 52%;
-  left: 50%;
-  width: clamp(280px, 32vw, 460px);
-  height: clamp(140px, 17vw, 240px);
-  transform: translate3d(-50%, -50%, 0);
-  transform-origin: 50% 50%;
-  animation: turtleSwim 4.5s ease-in-out infinite;
-  pointer-events: auto;
-  will-change: transform;
-}
-
-.turtle-canvas {
-  display: block;
-  width: 100% !important;
-  height: 100% !important;
-}
-
-@keyframes turtleSwim {
-  0%,
-  100% {
-    transform: translate3d(-50%, -50%, 0) rotate(-2deg);
-  }
-  50% {
-    transform: translate3d(calc(-50% + 14px), calc(-50% - 10px), 0) rotate(2deg);
-  }
-}
-
 a {
   pointer-events: all;
   cursor: pointer;
@@ -314,12 +285,6 @@ a:visited {
   .nav a {
     margin-left: 10px;
     font-size: 0.85rem;
-  }
-
-  .turtle-stage {
-    top: 38%;
-    width: clamp(240px, 72vw, 360px);
-    height: clamp(120px, 36vw, 190px);
   }
 
   .cause-info {


### PR DESCRIPTION
## Job
Restore the About turtle aquarium visual treatment removed by PR #18.

Closes #21

## What changed
- Reverts `ebd7319` / PR #18.
- Restores the aquarium model, floating bubbles, `Float`, `useAnimations`, `AutoInvalidate`, and the previous turtle smoothness checker script.
- Removes the CSS wrapper animation that made the turtle look like a flat static cutout.

## What went wrong
The previous fix optimized the About page by replacing the animated turtle scene with a small static canvas animated by CSS. That solved the profiler number but removed the aquarium/transparent-glass context, bubble motion, and skinned turtle animation. It treated the visual system as expendable instead of preserving it.

## Exit criterion
`git grep -q "AQUARIUM_MODEL" -- react-three/src/TurtlePage.js && git grep -q "AutoInvalidate" -- react-three/src/TurtlePage.js && git grep -q "useAnimations" -- react-three/src/TurtlePage.js && test -f react-three/scripts/check-turtle-smoothness.mjs && cd react-three && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false && mise exec node@18.17.0 -- npm run build`

Raw output:
```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/TurtlePage.test.js
PASS src/App.test.js

Test Suites: 2 passed, 2 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        1.34 s
Ran all test suites.

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-revert-about/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-revert-about/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  522.84 kB  build/static/js/main.dddd5198.js
  33.31 kB   build/static/js/771.e2f0600b.chunk.js
  13.02 kB   build/static/js/419.913e5443.chunk.js
  1.4 kB     build/static/css/main.f4344f29.css
  1.33 kB    build/static/js/879.e349953e.chunk.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment
```

## Out of scope
- Did not attempt a new turtle performance optimization.
- Did not change `/rights`; that was restored in #20 / PR #22.
- Did not use port 3000.
