### PR TITLE
Fix About turtle idle framerate

### DIFF
--- a/react-three/src/TurtlePage.js
+++ b/react-three/src/TurtlePage.js
@@ -1,7 +1,8 @@
 import { useEffect } from 'react'
-import { Canvas, useFrame, useThree } from "@react-three/fiber"
+import { Canvas, useFrame } from "@react-three/fiber"
 import { Float } from "@react-three/drei"
 import { useGLTF, useAnimations, Instance, Instances, CameraControls } from "@react-three/drei"
+import { FrontSide } from "three"
 
 // Bubble configuration for turtle aquarium
 const spheres = [
@@ -27,13 +28,11 @@ const TURTLE_MODEL = '/turtle-draco.glb'
 export function TurtleCanvas() {
   return (
     <Canvas
-      dpr={[1, 1]}
-      frameloop="demand"
+      dpr={0.75}
       gl={{ antialias: false, powerPreference: "high-performance" }}
       camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}
     >
       <color attach="background" args={['#e0e0e0']} />
-      <AutoInvalidate fps={12} />
       <ambientLight intensity={0.45} />
       <directionalLight position={[-5, 10, -5]} intensity={1.5} />
       <Aquarium position={[0, 0.25, 0]}>
@@ -51,21 +50,6 @@ export function TurtleCanvas() {
       <CameraControls truckSpeed={0} dollySpeed={0} minPolarAngle={0} maxPolarAngle={Math.PI / 2} />
     </Canvas>
   )
-}
-
-export function AutoInvalidate({ fps = 8 }) {
-  const three = useThree()
-  const invalidate = typeof three === 'function' ? three : three?.invalidate
-
-  useEffect(() => {
-    if (typeof invalidate !== 'function') return undefined
-
-    invalidate()
-    const intervalId = setInterval(invalidate, 1000 / fps)
-    return () => clearInterval(intervalId)
-  }, [fps, invalidate])
-
-  return null
 }
 
 // Aquarium glass container
@@ -102,9 +86,22 @@ function Turtle(props) {
   const { scene, animations } = useGLTF(TURTLE_MODEL)
   const { actions, mixer } = useAnimations(animations, scene)
   useEffect(() => {
+    setFrontSideMaterials(scene)
+  }, [scene])
+  useEffect(() => {
     mixer.timeScale = 0.5
     actions['Swim Cycle']?.play()
   }, [actions, mixer])
   useFrame((state) => (scene.rotation.z = Math.sin(state.clock.elapsedTime / 4) / 4))
   return <primitive object={scene} {...props} />
+}
+
+export function setFrontSideMaterials(scene) {
+  scene.traverse((object) => {
+    const materials = Array.isArray(object.material) ? object.material : object.material ? [object.material] : []
+    materials.forEach((material) => {
+      material.side = FrontSide
+      material.needsUpdate = true
+    })
+  })
 }

--- a/react-three/src/TurtlePage.test.js
+++ b/react-three/src/TurtlePage.test.js
@@ -5,17 +5,20 @@ import { createRoot } from "react-dom/client"
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
 let canvasProps
-let autoInvalidateProps
-const mockInvalidate = jest.fn()
-let mockIntervalCallback
+let heartbeatProps
+
+jest.mock("three", () => ({
+  DoubleSide: 2,
+  FrontSide: 0
+}))
 
 jest.mock("@react-three/fiber", () => ({
   Canvas: ({ children, ...props }) => {
     const React = require("react")
-    const autoInvalidate = React.Children.toArray(children).find((child) => child.type?.name === "AutoInvalidate")
+    const heartbeat = React.Children.toArray(children).find((child) => child.type?.name?.includes("Invalidate"))
 
     canvasProps = props
-    autoInvalidateProps = autoInvalidate?.props
+    heartbeatProps = heartbeat?.props
 
     return <div data-testid="turtle-canvas" />
   },
@@ -40,24 +43,14 @@ jest.mock("@react-three/drei", () => ({
 }))
 
 describe("TurtleCanvas", () => {
-  const { useThree } = require("@react-three/fiber")
-  const { TurtleCanvas, AutoInvalidate } = require("./TurtlePage")
+  const { TurtleCanvas, setFrontSideMaterials } = require("./TurtlePage")
+  const { DoubleSide, FrontSide } = require("three")
   let container
   let root
 
   beforeEach(() => {
     canvasProps = undefined
-    autoInvalidateProps = undefined
-    mockInvalidate.mockClear()
-    useThree.mockReturnValue({ invalidate: mockInvalidate })
-    mockIntervalCallback = undefined
-    global.setInterval = jest.fn((callback) => {
-      mockIntervalCallback = callback
-      return 1
-    })
-    global.clearInterval = jest.fn()
-    window.setInterval = global.setInterval
-    window.clearInterval = global.clearInterval
+    heartbeatProps = undefined
     container = document.createElement("div")
     document.body.appendChild(container)
     root = createRoot(container)
@@ -68,25 +61,31 @@ describe("TurtleCanvas", () => {
     container.remove()
   })
 
-  it("keeps the optimized demand frame loop", () => {
+  it("uses the continuous frame loop for smooth idle animation", () => {
     act(() => root.render(<TurtleCanvas />))
 
-    expect(canvasProps.frameloop).toBe("demand")
+    expect(canvasProps.frameloop).toBeUndefined()
   })
 
-  it("uses a smooth automatic render cadence on the page", () => {
+  it("caps the internal drawing buffer below full DPR", () => {
     act(() => root.render(<TurtleCanvas />))
 
-    expect(autoInvalidateProps.fps).toBeGreaterThanOrEqual(12)
+    expect(canvasProps.dpr).toBe(0.75)
   })
 
-  it("invalidates frames automatically so the turtle animates without a click", async () => {
-    await act(async () => root.render(<AutoInvalidate fps={8} />))
+  it("does not cap idle animation with a manual invalidation heartbeat", () => {
+    act(() => root.render(<TurtleCanvas />))
 
-    expect(global.setInterval).toHaveBeenCalledWith(expect.any(Function), 125)
-    expect(mockInvalidate).toHaveBeenCalledTimes(1)
+    expect(heartbeatProps).toBeUndefined()
+  })
 
-    act(() => mockIntervalCallback())
-    expect(mockInvalidate).toHaveBeenCalledTimes(2)
+  it("renders turtle materials front-sided to avoid extra fragment work", () => {
+    const material = { side: DoubleSide, needsUpdate: false }
+    const scene = { traverse: (visit) => visit({ material }) }
+
+    setFrontSideMaterials(scene)
+
+    expect(material.side).toBe(FrontSide)
+    expect(material.needsUpdate).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #25

## Summary
- Restores continuous rendering for the About turtle/aquarium route so it animates before any pointer interaction.
- Keeps the turtle/aquarium visual system intact while lowering render cost with a fixed DPR cap and front-sided model materials.
- Removes the manual invalidation heartbeat that capped idle animation.

## Exit criterion
`cd react-three && ! git grep -q "frameloop=\"demand\"" -- src/TurtlePage.js && ! git grep -q "AutoInvalidate" -- src/TurtlePage.js src/TurtlePage.test.js && git grep -q "dpr={0.75}" -- src/TurtlePage.js && git grep -q "setFrontSideMaterials" -- src/TurtlePage.js src/TurtlePage.test.js && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false && mise exec node@18.17.0 -- npm run build && (PORT=3102 BROWSER=none HOST=127.0.0.1 mise exec node@18.17.0 -- npm start > /tmp/aviyashchin-issue25-server.log 2>&1 & echo $! > /tmp/aviyashchin-issue25-server.pid) && trap "kill $(cat /tmp/aviyashchin-issue25-server.pid) 2>/dev/null || true" EXIT && until curl -fsS http://127.0.0.1:3102/about >/dev/null; do sleep 1; done && mise exec node@18.17.0 -- node scripts/check-turtle-smoothness.mjs --url http://127.0.0.1:3102/about --duration 5000 --min-active-frames 60 --max-frame-gap-ms 220`

## Exit output
```text
PASS src/TurtlePage.test.js
PASS src/App.test.js

Test Suites: 2 passed, 2 total
Tests:       6 passed, 6 total
Snapshots:   0 total

Compiled with warnings.
Failed to parse source map from node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map (existing upstream sourcemap warning).

Turtle smoothness check
URL: http://127.0.0.1:3102/about
Status: ok
Sample window: 5000ms

Motion:
  changed pixels: 2670 / 6868
  changed ratio:  0.3888

Render cadence:
  draw calls:      1078
  render frames:   154
  avg gap:         36.8ms
  p95 gap:         50.3ms
  max gap:         87.3ms

DOM:
  about text:      true
  canvas count:    1

Thresholds:
  pass changed ratio: 0.3888 >= 0.0100
  pass active frames: 154.0000 >= 60.0000
  pass frame gap p95: 50.3ms <= 220.0ms
```

## Cut from scope
- Did not simplify/remove the aquarium, transparency, turtle model, bubbles, Float, useAnimations, lighting, or camera controls.
- Did not touch `/rights` or `/demos`.