### PR TITLE
Improve About turtle idle framerate

### DIFF
--- a/react-three/src/TurtlePage.js
+++ b/react-three/src/TurtlePage.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { Canvas, useFrame } from "@react-three/fiber"
 import { Float } from "@react-three/drei"
 import { useGLTF, useAnimations, Instance, Instances, CameraControls } from "@react-three/drei"
-import { FrontSide } from "three"
+import { FrontSide, MeshPhongMaterial } from "three"
 
 // Bubble configuration for turtle aquarium
 const spheres = [
@@ -28,7 +28,8 @@ const TURTLE_MODEL = '/turtle-draco.glb'
 export function TurtleCanvas() {
   return (
     <Canvas
-      dpr={0.75}
+      dpr={0.5}
+      flat
       gl={{ antialias: false, powerPreference: "high-performance" }}
       camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}
     >
@@ -86,7 +87,7 @@ function Turtle(props) {
   const { scene, animations } = useGLTF(TURTLE_MODEL)
   const { actions, mixer } = useAnimations(animations, scene)
   useEffect(() => {
-    setFrontSideMaterials(scene)
+    optimizeTurtleMaterials(scene)
   }, [scene])
   useEffect(() => {
     mixer.timeScale = 0.5
@@ -96,12 +97,26 @@ function Turtle(props) {
   return <primitive object={scene} {...props} />
 }
 
-export function setFrontSideMaterials(scene) {
+export function optimizeTurtleMaterials(scene) {
   scene.traverse((object) => {
     const materials = Array.isArray(object.material) ? object.material : object.material ? [object.material] : []
-    materials.forEach((material) => {
-      material.side = FrontSide
-      material.needsUpdate = true
+    materials.forEach((material, index) => {
+      const optimized = createTurtleMaterial(material)
+
+      if (Array.isArray(object.material)) object.material[index] = optimized
+      else object.material = optimized
     })
+  })
+}
+
+export function createTurtleMaterial(source) {
+  return new MeshPhongMaterial({
+    color: source.color || 'white',
+    map: source.map || null,
+    alphaMap: source.alphaMap || null,
+    transparent: source.transparent,
+    opacity: source.opacity,
+    side: FrontSide,
+    skinning: source.skinning
   })
 }

--- a/react-three/src/TurtlePage.test.js
+++ b/react-three/src/TurtlePage.test.js
@@ -9,7 +9,10 @@ let heartbeatProps
 
 jest.mock("three", () => ({
   DoubleSide: 2,
-  FrontSide: 0
+  FrontSide: 0,
+  MeshPhongMaterial: jest.fn(function MeshPhongMaterial(props) {
+    Object.assign(this, props)
+  })
 }))
 
 jest.mock("@react-three/fiber", () => ({
@@ -43,8 +46,8 @@ jest.mock("@react-three/drei", () => ({
 }))
 
 describe("TurtleCanvas", () => {
-  const { TurtleCanvas, setFrontSideMaterials } = require("./TurtlePage")
-  const { DoubleSide, FrontSide } = require("three")
+  const { TurtleCanvas, optimizeTurtleMaterials } = require("./TurtlePage")
+  const { DoubleSide, FrontSide, MeshPhongMaterial } = require("three")
   let container
   let root
 
@@ -70,7 +73,13 @@ describe("TurtleCanvas", () => {
   it("caps the internal drawing buffer below full DPR", () => {
     act(() => root.render(<TurtleCanvas />))
 
-    expect(canvasProps.dpr).toBe(0.75)
+    expect(canvasProps.dpr).toBe(0.5)
+  })
+
+  it("uses flat canvas color output to avoid extra tone-mapping work", () => {
+    act(() => root.render(<TurtleCanvas />))
+
+    expect(canvasProps.flat).toBe(true)
   })
 
   it("does not cap idle animation with a manual invalidation heartbeat", () => {
@@ -79,13 +88,32 @@ describe("TurtleCanvas", () => {
     expect(heartbeatProps).toBeUndefined()
   })
 
-  it("renders turtle materials front-sided to avoid extra fragment work", () => {
-    const material = { side: DoubleSide, needsUpdate: false }
-    const scene = { traverse: (visit) => visit({ material }) }
+  it("replaces turtle PBR materials with front-sided textured Phong materials", () => {
+    const map = { isTexture: true }
+    const alphaMap = { isTexture: true }
+    const material = {
+      color: "green",
+      map,
+      alphaMap,
+      transparent: true,
+      opacity: 0.8,
+      side: DoubleSide,
+      skinning: true
+    }
+    const object = { material }
+    const scene = { traverse: (visit) => visit(object) }
 
-    setFrontSideMaterials(scene)
+    optimizeTurtleMaterials(scene)
 
-    expect(material.side).toBe(FrontSide)
-    expect(material.needsUpdate).toBe(true)
+    expect(MeshPhongMaterial).toHaveBeenCalledWith({
+      color: "green",
+      map,
+      alphaMap,
+      transparent: true,
+      opacity: 0.8,
+      side: FrontSide,
+      skinning: true
+    })
+    expect(object.material).toBeInstanceOf(MeshPhongMaterial)
   })
 })


### PR DESCRIPTION
Closes #29

## Summary
- Lower the About turtle canvas DPR to 0.5 and enable flat color output.
- Replace the turtle GLB's heavier PBR materials at runtime with textured, front-sided `MeshPhongMaterial` instances.
- Keep the turtle model, aquarium shell, bubbles, swim animation, idle rock, and drag controls intact.

## Root Cause
The remaining idle lag was not caused by `frameloop`, controls, bubbles, or skeletal animation. Local variant checks showed controls had no benefit, disabling swim did not improve cadence, and removing the turtle model was the major jump. The turtle model is small (~5.8k triangles), so the bottleneck was per-frame turtle material/shader work combined with canvas resolution.

## Exit Criterion
`cd react-three && ! git grep -q "frameloop=\"demand\"" -- src/TurtlePage.js && git grep -q "dpr={0.5}" -- src/TurtlePage.js && git grep -q "flat" -- src/TurtlePage.js src/TurtlePage.test.js && git grep -q "MeshPhongMaterial" -- src/TurtlePage.js src/TurtlePage.test.js && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false && mise exec node@18.17.0 -- npm run build && (python3 -m http.server 3105 --bind 127.0.0.1 --directory build > /tmp/aviyashchin-issue29-static.log 2>&1 & echo $! > /tmp/aviyashchin-issue29-static.pid) && trap "kill $(cat /tmp/aviyashchin-issue29-static.pid) 2>/dev/null || true" EXIT && until curl -fsS http://127.0.0.1:3105/ >/dev/null; do sleep 1; done && mise exec node@18.17.0 -- node scripts/check-turtle-smoothness.mjs --url http://127.0.0.1:3105/ --duration 5000 --min-active-frames 200 --max-frame-gap-ms 45`

## Exit Output
```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/TurtlePage.test.js
PASS src/App.test.js

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.247 s
Ran all test suites.

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-issue-29/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-issue-29/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  522.84 kB  build/static/js/main.a66699cc.js
  33.31 kB   build/static/js/771.e2f0600b.chunk.js
  13.02 kB   build/static/js/419.913e5443.chunk.js
  1.4 kB     build/static/css/main.f4344f29.css
  1.37 kB    build/static/js/879.552d4da7.chunk.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

curl: (7) Failed to connect to 127.0.0.1 port 3105 after 0 ms: Couldn't connect to server
Turtle smoothness check
URL: http://127.0.0.1:3105/
Status: ok
Sample window: 5000ms

Motion:
  changed pixels: 2912 / 6868
  changed ratio:  0.4240

Render cadence:
  draw calls:      1449
  render frames:   207
  avg gap:         26.7ms
  p95 gap:         39.4ms
  max gap:         49.2ms

DOM:
  about text:      true
  canvas count:    1

Thresholds:
  pass changed ratio: 0.4240 >= 0.0100
  pass active frames: 207.0000 >= 200.0000
  pass frame gap p95: 39.4ms <= 45.0ms
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved turtle rendering by switching to a more consistent material setup for loaded models.
  * Turtle visuals now preserve key texture and transparency properties while enforcing front-side rendering.
  * Updated canvas settings for smoother performance, including a lower pixel ratio cap and flat shading support.

* **Tests**
  * Updated automated checks to match the new rendering and material behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->