### PR TITLE
Restore About turtle render sharpness

### DIFF
--- a/react-three/src/TurtlePage.js
+++ b/react-three/src/TurtlePage.js
@@ -28,7 +28,7 @@ const TURTLE_MODEL = '/turtle-draco.glb'
 export function TurtleCanvas() {
   return (
     <Canvas
-      dpr={0.75}
+      dpr={0.7}
       flat
       gl={{ antialias: false, powerPreference: "high-performance" }}
       camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}

--- a/react-three/src/TurtlePage.js
+++ b/react-three/src/TurtlePage.js
@@ -28,7 +28,7 @@ const TURTLE_MODEL = '/turtle-draco.glb'
 export function TurtleCanvas() {
   return (
     <Canvas
-      dpr={0.5}
+      dpr={0.75}
       flat
       gl={{ antialias: false, powerPreference: "high-performance" }}
       camera={{ position: [30, 0, -3], fov: 35, near: 1, far: 50 }}

--- a/react-three/src/TurtlePage.test.js
+++ b/react-three/src/TurtlePage.test.js
@@ -73,7 +73,7 @@ describe("TurtleCanvas", () => {
   it("caps the internal drawing buffer below full DPR", () => {
     act(() => root.render(<TurtleCanvas />))
 
-    expect(canvasProps.dpr).toBe(0.5)
+    expect(canvasProps.dpr).toBe(0.75)
   })
 
   it("uses flat canvas color output to avoid extra tone-mapping work", () => {

--- a/react-three/src/TurtlePage.test.js
+++ b/react-three/src/TurtlePage.test.js
@@ -73,7 +73,7 @@ describe("TurtleCanvas", () => {
   it("caps the internal drawing buffer below full DPR", () => {
     act(() => root.render(<TurtleCanvas />))
 
-    expect(canvasProps.dpr).toBe(0.75)
+    expect(canvasProps.dpr).toBe(0.7)
   })
 
   it("uses flat canvas color output to avoid extra tone-mapping work", () => {


### PR DESCRIPTION
Closes #31

## Summary
- Raises the About turtle canvas DPR from `0.5` to `0.7` so the turtle no longer renders overly soft.
- Keeps the prior material optimization and flat output that improved idle cadence.
- Leaves the turtle model, aquarium shell, bubbles, swim animation, idle rock, and drag controls intact.
- Rebased on top of the merged `/rights` performance PR.

## Root Cause
PR #30 improved cadence by cutting the About canvas DPR to `0.5`, which made the turtle visibly low resolution. Full DPR (`1`) measured too slow at 124 render frames / 5s with p95 gap 71ms. DPR `0.75` was sharper but unstable on rerun after the `/rights` merge. DPR `0.7` restores much of the lost resolution while keeping the idle smoothness gate stable.

## Exit Criterion
`cd react-three && git grep -q "dpr={0.7}" -- src/TurtlePage.js src/TurtlePage.test.js && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false --silent && mise exec node@18.17.0 -- npm run build && (python3 -m http.server 3110 --bind 127.0.0.1 --directory build > /tmp/aviyashchin-issue31-static.log 2>&1 & echo $! > /tmp/aviyashchin-issue31-static.pid) && trap "kill $(cat /tmp/aviyashchin-issue31-static.pid) 2>/dev/null || true" EXIT && until curl -fsS http://127.0.0.1:3110/ >/dev/null; do sleep 1; done && mise exec node@18.17.0 -- node scripts/check-turtle-smoothness.mjs --url http://127.0.0.1:3110/ --duration 5000 --min-active-frames 150 --max-frame-gap-ms 65`

## Exit Output
```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false --silent

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/App.test.js
PASS src/TurtlePage.test.js

Test Suites: 2 passed, 2 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        1.171 s

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-issue-31/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-issue-31/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  519.94 kB       build/static/js/main.494a8e49.js
  33.31 kB        build/static/js/771.e2f0600b.chunk.js
  13.02 kB        build/static/js/419.913e5443.chunk.js
  1.4 kB          build/static/css/main.f4344f29.css
  1.37 kB (+1 B)  build/static/js/879.62293998.chunk.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

curl: (7) Failed to connect to 127.0.0.1 port 3110 after 0 ms: Couldn't connect to server
Turtle smoothness check
URL: http://127.0.0.1:3110/
Status: ok
Sample window: 5000ms

Motion:
  changed pixels: 3010 / 6868
  changed ratio:  0.4383

Render cadence:
  draw calls:      1204
  render frames:   172
  avg gap:         32.5ms
  p95 gap:         46.8ms
  max gap:         98.2ms

DOM:
  about text:      true
  canvas count:    1

Thresholds:
  pass changed ratio: 0.4383 >= 0.0100
  pass active frames: 172.0000 >= 150.0000
  pass frame gap p95: 46.8ms <= 65.0ms
```
