### PR TITLE
Restore cause-route automatic motion

### DIFF
--- a/react-three/scripts/check-route-motion.mjs
+++ b/react-three/scripts/check-route-motion.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+import { chromium } from "playwright"
+
+const DEFAULT_DURATION_MS = 5000
+const DEFAULT_TIMEOUT_MS = 15000
+const DEFAULT_CHANNEL = "chrome"
+
+function printHelp() {
+  console.log(`Usage: node scripts/check-route-motion.mjs --url <url> [options]
+
+Checks that a route has visible automatic canvas motion without interaction.
+
+Options:
+  --url <url>                  Page URL to check.
+  --duration <ms>              Sample window. Default: ${DEFAULT_DURATION_MS}
+  --timeout <ms>               Navigation/canvas timeout. Default: ${DEFAULT_TIMEOUT_MS}
+  --channel <name>             Chromium channel, or "bundled". Default: ${DEFAULT_CHANNEL}
+  --headed                     Run Chrome headed instead of headless.
+  --min-changed-ratio <ratio>  Minimum screenshot pixel-change ratio.
+  --min-active-frames <count>  Minimum WebGL render frames during the sample.
+  --json                       Print only JSON.
+  --help                       Show this help.
+`)
+}
+
+function readOption(args, name, fallback) {
+  for (let index = args.length - 1; index >= 0; index -= 1) {
+    const arg = args[index]
+    if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1)
+    if (arg === name && args[index + 1]) return args[index + 1]
+  }
+  return fallback
+}
+
+function readNumber(args, name, fallback, { allowZero = true } = {}) {
+  const value = readOption(args, name, fallback)
+  const parsed = Number(value)
+
+  if (!Number.isFinite(parsed) || (allowZero ? parsed < 0 : parsed <= 0)) {
+    throw new Error(`${name} must be a ${allowZero ? "non-negative" : "positive"} number`)
+  }
+
+  return parsed
+}
+
+function parseArgs(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) return { help: true }
+
+  const url = readOption(argv, "--url", null)
+  if (!url) throw new Error("--url is required")
+
+  return {
+    help: false,
+    url,
+    duration: readNumber(argv, "--duration", DEFAULT_DURATION_MS, { allowZero: false }),
+    timeout: readNumber(argv, "--timeout", DEFAULT_TIMEOUT_MS, { allowZero: false }),
+    channel: readOption(argv, "--channel", DEFAULT_CHANNEL),
+    headed: argv.includes("--headed"),
+    json: argv.includes("--json"),
+    thresholds: {
+      minChangedRatio: readNumber(argv, "--min-changed-ratio", 0.01),
+      minActiveFrames: readNumber(argv, "--min-active-frames", 1)
+    }
+  }
+}
+
+function toDataUrl(buffer) {
+  return `data:image/png;base64,${buffer.toString("base64")}`
+}
+
+function groupRenderFrames(times) {
+  const frames = []
+
+  for (const time of times) {
+    const last = frames[frames.length - 1]
+
+    if (!last || time - last.last > 10) {
+      frames.push({ first: time, last: time, drawCalls: 1 })
+    } else {
+      last.last = time
+      last.drawCalls += 1
+    }
+  }
+
+  return frames
+}
+
+function summarizeFrames(events) {
+  const frameIds = new Set(events.map((event) => event.frame).filter((frame) => frame > 0))
+  const frames = frameIds.size ? [] : groupRenderFrames(events.map((event) => event.time))
+
+  return {
+    drawCalls: events.length,
+    renderFrames: frameIds.size || frames.length
+  }
+}
+
+function evaluateThresholds(report) {
+  const checks = [
+    {
+      name: "changed ratio",
+      actual: report.changedRatio,
+      min: report.options.thresholds.minChangedRatio,
+      passed: report.changedRatio >= report.options.thresholds.minChangedRatio
+    },
+    {
+      name: "active frames",
+      actual: report.frames.renderFrames,
+      min: report.options.thresholds.minActiveFrames,
+      passed: report.frames.renderFrames >= report.options.thresholds.minActiveFrames
+    }
+  ]
+
+  return {
+    passed: checks.every((check) => check.passed),
+    checks
+  }
+}
+
+function formatNumber(value, digits = 3) {
+  return Number(value || 0).toFixed(digits)
+}
+
+function printHuman(report) {
+  console.log(`Route motion check
+URL: ${report.url}
+Status: ${report.status}
+Sample window: ${report.options.duration}ms
+
+Motion:
+  changed pixels: ${report.changed} / ${report.sampled}
+  changed ratio:  ${formatNumber(report.changedRatio, 4)}
+
+Render cadence:
+  draw calls:      ${report.frames.drawCalls}
+  render frames:   ${report.frames.renderFrames}
+
+DOM:
+  canvas count:    ${report.canvasCount}
+
+Thresholds:`)
+
+  for (const check of report.thresholds.checks) {
+    console.log(`  ${check.passed ? "pass" : "fail"} ${check.name}: ${formatNumber(check.actual, 4)} >= ${formatNumber(check.min, 4)}`)
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    printHelp()
+    return
+  }
+
+  const launchOptions = {
+    headless: !options.headed,
+    args: ["--enable-unsafe-webgpu", "--ignore-gpu-blocklist", "--use-angle=default"]
+  }
+
+  if (options.channel !== "bundled") launchOptions.channel = options.channel
+
+  let browser
+
+  try {
+    browser = await chromium.launch(launchOptions)
+    const page = await browser.newPage({
+      viewport: { width: 1440, height: 900 },
+      deviceScaleFactor: 1
+    })
+
+    await page.addInitScript(() => {
+      window.__routeDrawEvents = []
+      window.__routeRafFrame = 0
+
+      const nativeRequestAnimationFrame = window.requestAnimationFrame.bind(window)
+      window.requestAnimationFrame = (callback) => nativeRequestAnimationFrame((time) => {
+        window.__routeRafFrame += 1
+        return callback(time)
+      })
+
+      for (const name of ["WebGLRenderingContext", "WebGL2RenderingContext"]) {
+        const Context = window[name]
+        if (!Context) continue
+
+        for (const method of ["drawArrays", "drawElements", "drawArraysInstanced", "drawElementsInstanced"]) {
+          const original = Context.prototype[method]
+          if (typeof original !== "function") continue
+
+          Context.prototype[method] = function (...args) {
+            window.__routeDrawEvents.push({
+              frame: window.__routeRafFrame,
+              time: performance.now()
+            })
+            return original.apply(this, args)
+          }
+        }
+      }
+    })
+
+    await page.goto(options.url, {
+      waitUntil: "domcontentloaded",
+      timeout: options.timeout
+    })
+
+    await page.waitForSelector("canvas", { timeout: options.timeout })
+    await page.waitForTimeout(1500)
+    await page.evaluate(() => { window.__routeDrawEvents = [] })
+
+    const first = await page.screenshot({ fullPage: false })
+    await page.waitForTimeout(options.duration)
+    const second = await page.screenshot({ fullPage: false })
+    const drawEvents = await page.evaluate(() => window.__routeDrawEvents.slice())
+
+    const motion = await page.evaluate(async ({ firstUrl, secondUrl }) => {
+      async function load(url) {
+        const image = new Image()
+        image.src = url
+        await image.decode()
+
+        const canvas = document.createElement("canvas")
+        canvas.width = image.naturalWidth
+        canvas.height = image.naturalHeight
+
+        const context = canvas.getContext("2d")
+        context.drawImage(image, 0, 0)
+
+        return {
+          data: context.getImageData(0, 0, canvas.width, canvas.height).data,
+          width: canvas.width,
+          height: canvas.height
+        }
+      }
+
+      const a = await load(firstUrl)
+      const b = await load(secondUrl)
+      const left = Math.floor(a.width * 0.12)
+      const top = Math.floor(a.height * 0.12)
+      const right = Math.floor(a.width * 0.82)
+      const bottom = Math.floor(a.height * 0.82)
+      let changed = 0
+      let sampled = 0
+
+      for (let y = top; y < bottom; y += 8) {
+        for (let x = left; x < right; x += 8) {
+          const index = (y * a.width + x) * 4
+          const delta = Math.abs(a.data[index] - b.data[index]) +
+            Math.abs(a.data[index + 1] - b.data[index + 1]) +
+            Math.abs(a.data[index + 2] - b.data[index + 2]) +
+            Math.abs(a.data[index + 3] - b.data[index + 3])
+
+          sampled += 1
+          if (delta > 18) changed += 1
+        }
+      }
+
+      return {
+        changed,
+        sampled,
+        changedRatio: changed / sampled,
+        canvasCount: document.querySelectorAll("canvas").length
+      }
+    }, {
+      firstUrl: toDataUrl(first),
+      secondUrl: toDataUrl(second)
+    })
+
+    const report = {
+      status: "ok",
+      url: page.url(),
+      options,
+      ...motion,
+      frames: summarizeFrames(drawEvents)
+    }
+
+    report.thresholds = evaluateThresholds(report)
+    report.status = report.thresholds.passed && report.canvasCount === 1 ? "ok" : "threshold-failed"
+
+    if (options.json) console.log(JSON.stringify(report, null, 2))
+    else printHuman(report)
+
+    if (report.status !== "ok") process.exitCode = 1
+  } finally {
+    if (browser) await browser.close()
+  }
+}
+
+main().catch((error) => {
+  console.error(`check-route-motion failed: ${error.message}`)
+  process.exit(1)
+})

--- a/react-three/scripts/profile-rights.mjs
+++ b/react-three/scripts/profile-rights.mjs
@@ -240,7 +240,7 @@ async function main() {
 
   const launchOptions = {
     headless: !options.headed,
-    args: ["--enable-unsafe-webgpu", "--enable-unsafe-swiftshader"]
+    args: ["--enable-unsafe-webgpu", "--ignore-gpu-blocklist", "--use-angle=default"]
   }
 
   if (options.channel !== "bundled") {

--- a/react-three/src/App.js
+++ b/react-three/src/App.js
@@ -24,7 +24,7 @@ const mainSceneQuality = {
     dpr: [1, 1.5],
     transmission: { samples: 2, resolution: 256, backsideResolution: 128 },
     contactShadowResolution: 256,
-    composerMultisampling: 2,
+    composerMultisampling: 0,
     bloomLevels: 4
   }
 }
@@ -74,7 +74,7 @@ function MainCanvas() {
       eventSource={document.getElementById("root")}
       eventPrefix="client"
       shadows
-      frameloop="demand"
+      gl={{ powerPreference: "high-performance" }}
       dpr={quality.dpr}
       camera={{ position: [0, 0, 20], fov: 50 }}
     >

--- a/react-three/src/App.test.js
+++ b/react-three/src/App.test.js
@@ -85,12 +85,11 @@ describe("App about route", () => {
   })
 })
 
-describe("App rights route performance budget", () => {
+describe("App cause route render loops", () => {
   let container
   let root
 
   beforeEach(() => {
-    window.history.pushState({}, "", "/rights")
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
       writable: true,
@@ -107,13 +106,16 @@ describe("App rights route performance budget", () => {
     window.history.pushState({}, "", "/")
   })
 
-  it("keeps the glass scene while capping idle render cost", async () => {
+  it("keeps /rights on the continuous frame loop without reducing scene quality", async () => {
+    window.history.pushState({}, "", "/rights")
+
     await act(async () => root.render(<App />))
 
     expect(readProps(container, "canvas")).toEqual(expect.objectContaining({
       dpr: [1, 1.5],
-      frameloop: "demand"
+      gl: { powerPreference: "high-performance" }
     }))
+    expect(readProps(container, "canvas").frameloop).toBeUndefined()
 
     const materialProps = readProps(container, "mesh-transmission-material")
     expect(materialProps).toEqual(expect.objectContaining({
@@ -135,7 +137,7 @@ describe("App rights route performance budget", () => {
 
     expect(readProps(container, "effect-composer")).toEqual(expect.objectContaining({
       disableNormalPass: true,
-      multisampling: 2
+      multisampling: 0
     }))
     expect(readProps(container, "n8ao").intensity).toBe(2)
     expect(readProps(container, "bloom")).toEqual(expect.objectContaining({
@@ -143,6 +145,22 @@ describe("App rights route performance budget", () => {
       levels: 4
     }))
     expect(readProps(container, "tilt-shift").blur).toBe(0.2)
+  })
+
+  it("keeps /activism on the continuous frame loop for visible idle motion", async () => {
+    window.history.pushState({}, "", "/activism")
+
+    await act(async () => root.render(<App />))
+
+    expect(readProps(container, "canvas").frameloop).toBeUndefined()
+  })
+
+  it("keeps /charity on the continuous frame loop for visible idle motion", async () => {
+    window.history.pushState({}, "", "/charity")
+
+    await act(async () => root.render(<App />))
+
+    expect(readProps(container, "canvas").frameloop).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- Restores automatic motion on `/rights`, `/activism`, and `/charity` by removing the global demand render loop.
- Keeps the existing glass material, transparency/backside rendering, AO, bloom, tilt-shift, geometry, DPR, and shadows intact.
- Reduces composer render-target cost with `multisampling={0}` and adds a high-performance WebGL context preference.
- Adds a Playwright motion checker for route-level frozen-frame regressions.

Closes #33

## Exit criterion
`cd react-three && CI=true mise exec node@18.17.0 -- npm test -- --watchAll=false --silent && mise exec node@18.17.0 -- npm run build && (PORT=3113 BROWSER=none HOST=127.0.0.1 mise exec node@18.17.0 -- npm start > /tmp/aviyashchin-issue33-server.log 2>&1 & echo $! > /tmp/aviyashchin-issue33-server.pid) && trap "kill $(cat /tmp/aviyashchin-issue33-server.pid) 2>/dev/null || true" EXIT && until curl -fsS http://127.0.0.1:3113/activism >/dev/null; do sleep 1; done && mise exec node@18.17.0 -- node scripts/check-route-motion.mjs --url http://127.0.0.1:3113/rights --duration 5000 --min-active-frames 25 --min-changed-ratio 0.01 && mise exec node@18.17.0 -- node scripts/check-route-motion.mjs --url http://127.0.0.1:3113/activism --duration 5000 --min-active-frames 25 --min-changed-ratio 0.01 && mise exec node@18.17.0 -- node scripts/check-route-motion.mjs --url http://127.0.0.1:3113/charity --duration 5000 --min-active-frames 25 --min-changed-ratio 0.01 && mise exec node@18.17.0 -- node scripts/profile-rights.mjs --url http://127.0.0.1:3113/rights --duration 5000 --warmup 8000 --max-long-task-total 1200 --max-console-warnings 20`

## Raw output
```text
> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false --silent

PASS src/App.test.js
PASS src/TurtlePage.test.js

Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        0.772 s, estimated 1 s

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-issue-33/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-issue-33/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

File sizes after gzip:

  519.95 kB  build/static/js/main.69e36a5c.js
  33.31 kB   build/static/js/771.e2f0600b.chunk.js
  13.02 kB   build/static/js/419.913e5443.chunk.js
  1.4 kB     build/static/css/main.f4344f29.css
  1.37 kB    build/static/js/879.62293998.chunk.js

Route motion check
URL: http://127.0.0.1:3113/rights
Status: ok
Sample window: 5000ms

Motion:
  changed pixels: 2578 / 9954
  changed ratio:  0.2590

Render cadence:
  draw calls:      1683
  render frames:   51

DOM:
  canvas count:    1

Thresholds:
  pass changed ratio: 0.2590 >= 0.0100
  pass active frames: 51.0000 >= 25.0000
Route motion check
URL: http://127.0.0.1:3113/activism
Status: ok
Sample window: 5000ms

Motion:
  changed pixels: 1892 / 9954
  changed ratio:  0.1901

Render cadence:
  draw calls:      1584
  render frames:   48

DOM:
  canvas count:    1

Thresholds:
  pass changed ratio: 0.1901 >= 0.0100
  pass active frames: 48.0000 >= 25.0000
Route motion check
URL: http://127.0.0.1:3113/charity
Status: ok
Sample window: 5000ms

Motion:
  changed pixels: 1610 / 9954
  changed ratio:  0.1617

Render cadence:
  draw calls:      1221
  render frames:   37

DOM:
  canvas count:    1

Thresholds:
  pass changed ratio: 0.1617 >= 0.0100
  pass active frames: 37.0000 >= 25.0000
Route performance profile
URL: http://127.0.0.1:3113/rights
Status: ok
Readiness: domcontentloaded + canvas selector; networkidle intentionally skipped
Sample window: 5000ms
Warmup before sampling: 8000ms
Settle frames after warmup: 2

Navigation:
  domContentLoaded: 875.4ms
  loadEvent:        1028.4ms
  responseEnd:      14.3ms

Frame timing:
  frames:     31
  avg:        160.2ms (6.2 fps)
  min:        100.0ms
  p50/p95/p99:166.6ms / 233.3ms / 233.3ms
  max:        233.3ms
  >16.7ms:    31
  >33.3ms:    31
  >50ms:      31

Long tasks:
  supported: true
  count:     0
  total:     0.0ms
  max:       0.0ms

WebGL:
  available: true
  renderer:  ANGLE (Mesa, llvmpipe (LLVM 20.1.2 256 bits), OpenGL 4.5)
  vendor:    Google Inc. (Mesa)
  buffer:    1440x900
  css size:  1440x900
  ratio:     1.00
  antialias: true
  max texture/renderbuffer: 16384 / 16384
  extensions: 32

Chrome/CDP:
  task:        2130.5ms
  script:      1433.3ms
  layout:      61.0ms
  recalcStyle: 4.8ms
  nodes:       134

Console:
  warnings/errors: 0
  total messages:  2

Page errors:       0
Request failures:  0

Thresholds:
  pass long task total: 0.0ms <= 1200.0ms
  pass console warnings/errors: 0 <= 20
```

## Cut from scope
- Tested removing `backside` from `MeshTransmissionMaterial`; it improved the profiler but changed the refraction pattern, so it was reverted.
- Did not touch About/Turtle or Demos.