### PR TITLE
[codex] Add hidden WebGPU cloth page

### DIFF
--- a/react-three/package-lock.json
+++ b/react-three/package-lock.json
@@ -21,6 +21,7 @@
         "react-scripts": "5.0.1",
         "suspend-react": "0.1.3",
         "three": "0.154.0",
+        "three-webgpu": "npm:three@0.167.1",
         "wouter": "3.3.1"
       },
       "devDependencies": {
@@ -16690,6 +16691,13 @@
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
       "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
+    "node_modules/three-webgpu": {
+      "name": "three",
+      "version": "0.167.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
+      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw==",
       "license": "MIT"
     },
     "node_modules/throat": {

--- a/react-three/package.json
+++ b/react-three/package.json
@@ -22,6 +22,7 @@
     "react-scripts": "5.0.1",
     "suspend-react": "0.1.3",
     "three": "0.154.0",
+    "three-webgpu": "npm:three@0.167.1",
     "wouter": "3.3.1"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "build": "react-scripts build",
     "perf:route": "node scripts/profile-rights.mjs",
     "perf:rights": "node scripts/profile-rights.mjs --url http://127.0.0.1:3101/rights",
+    "verify:cloth-route": "npm test -- --watchAll=false --silent && npm run build && node scripts/check-cloth-route.mjs",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },

--- a/react-three/scripts/check-cloth-route.mjs
+++ b/react-three/scripts/check-cloth-route.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import http from "node:http"
+import path from "node:path"
+import { chromium } from "playwright"
+
+const DEFAULT_PORT = 3126
+const DEFAULT_TIMEOUT_MS = 20000
+const DEFAULT_CHANNEL = "chrome"
+const BUILD_DIR = path.resolve("build")
+
+function readOption(args, name, fallback) {
+  for (let index = args.length - 1; index >= 0; index -= 1) {
+    const arg = args[index]
+    if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1)
+    if (arg === name && args[index + 1]) return args[index + 1]
+  }
+  return fallback
+}
+
+function readNumber(args, name, fallback) {
+  const parsed = Number(readOption(args, name, fallback))
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error(`${name} must be a positive number`)
+  return parsed
+}
+
+function parseArgs(argv) {
+  return {
+    channel: readOption(argv, "--channel", DEFAULT_CHANNEL),
+    headed: argv.includes("--headed"),
+    port: readNumber(argv, "--port", DEFAULT_PORT),
+    timeout: readNumber(argv, "--timeout", DEFAULT_TIMEOUT_MS)
+  }
+}
+
+function contentType(filePath) {
+  const extension = path.extname(filePath)
+
+  return {
+    ".css": "text/css",
+    ".html": "text/html",
+    ".js": "text/javascript",
+    ".json": "application/json",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".txt": "text/plain",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2"
+  }[extension] || "application/octet-stream"
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function serveBuild(port) {
+  const server = http.createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url, `http://127.0.0.1:${port}`)
+      const pathname = decodeURIComponent(url.pathname)
+      const candidate = path.join(BUILD_DIR, pathname)
+      const filePath = await fileExists(candidate) && !candidate.endsWith(path.sep)
+        ? candidate
+        : path.join(BUILD_DIR, "index.html")
+
+      const body = await fs.readFile(filePath)
+      response.writeHead(200, { "content-type": contentType(filePath) })
+      response.end(body)
+    } catch (error) {
+      response.writeHead(500, { "content-type": "text/plain" })
+      response.end(error.message)
+    }
+  })
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(port, "127.0.0.1", resolve)
+  })
+
+  return server
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}
+
+function toDataUrl(buffer) {
+  return `data:image/png;base64,${buffer.toString("base64")}`
+}
+
+async function launchBrowser(options) {
+  const launchOptions = {
+    headless: !options.headed,
+    args: ["--enable-unsafe-webgpu", "--ignore-gpu-blocklist", "--use-angle=default"]
+  }
+
+  if (options.channel !== "bundled") launchOptions.channel = options.channel
+
+  try {
+    return await chromium.launch(launchOptions)
+  } catch (error) {
+    if (options.channel === "bundled") throw error
+    return chromium.launch({ ...launchOptions, channel: undefined })
+  }
+}
+
+async function compareScreenshots(page, first, second) {
+  return page.evaluate(async ({ firstUrl, secondUrl }) => {
+    async function load(url) {
+      const image = new Image()
+      image.src = url
+      await image.decode()
+
+      const canvas = document.createElement("canvas")
+      canvas.width = image.naturalWidth
+      canvas.height = image.naturalHeight
+
+      const context = canvas.getContext("2d")
+      context.drawImage(image, 0, 0)
+
+      return {
+        data: context.getImageData(0, 0, canvas.width, canvas.height).data,
+        height: canvas.height,
+        width: canvas.width
+      }
+    }
+
+    const a = await load(firstUrl)
+    const b = await load(secondUrl)
+    const left = Math.floor(a.width * 0.18)
+    const top = Math.floor(a.height * 0.16)
+    const right = Math.floor(a.width * 0.82)
+    const bottom = Math.floor(a.height * 0.82)
+    let changed = 0
+    let sampled = 0
+
+    for (let y = top; y < bottom; y += 8) {
+      for (let x = left; x < right; x += 8) {
+        const index = (y * a.width + x) * 4
+        const delta = Math.abs(a.data[index] - b.data[index]) +
+          Math.abs(a.data[index + 1] - b.data[index + 1]) +
+          Math.abs(a.data[index + 2] - b.data[index + 2]) +
+          Math.abs(a.data[index + 3] - b.data[index + 3])
+
+        sampled += 1
+        if (delta > 18) changed += 1
+      }
+    }
+
+    return {
+      changed,
+      changedRatio: changed / sampled,
+      sampled
+    }
+  }, {
+    firstUrl: toDataUrl(first),
+    secondUrl: toDataUrl(second)
+  })
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const server = await serveBuild(options.port)
+  let browser
+
+  try {
+    browser = await launchBrowser(options)
+    const page = await browser.newPage({
+      viewport: { width: 1440, height: 900 },
+      deviceScaleFactor: 1
+    })
+
+    const pageErrors = []
+    const consoleErrors = []
+
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text())
+    })
+
+    const url = `http://127.0.0.1:${options.port}/cloth`
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: options.timeout })
+    await page.waitForSelector(".cloth-page", { timeout: options.timeout })
+    await page.waitForFunction(() => {
+      const state = document.querySelector(".cloth-page")?.dataset.webgpuState
+      return state === "ready" || state === "fallback"
+    }, { timeout: options.timeout })
+
+    const state = await page.locator(".cloth-page").getAttribute("data-webgpu-state")
+    const navText = await page.locator(".nav").textContent()
+    const titleVisible = await page.getByRole("link", { name: "WebGPU Cloth" }).isVisible()
+    const canvasCount = await page.locator("canvas[data-motion-probe='webgpu-cloth']").count()
+    const fallbackVisible = await page.locator(".cloth-fallback-visual").isVisible().catch(() => false)
+    let motion = null
+
+    if (state === "ready") {
+      await page.waitForTimeout(1000)
+      const first = await page.screenshot({ fullPage: false })
+      await page.waitForTimeout(1200)
+      const second = await page.screenshot({ fullPage: false })
+      motion = await compareScreenshots(page, first, second)
+    }
+
+    const checks = [
+      { name: "cloth page reached terminal state", passed: state === "ready" || state === "fallback" },
+      { name: "cause overlay is present", passed: titleVisible },
+      { name: "hidden route is not in nav", passed: !navText.includes("cloth") },
+      { name: "no page errors", passed: pageErrors.length === 0 },
+      { name: "no console errors", passed: consoleErrors.length === 0 },
+      {
+        name: "visual is present",
+        passed: state === "ready" ? canvasCount === 1 : fallbackVisible
+      },
+      {
+        name: "ready scene has automatic motion",
+        passed: state === "fallback" || (motion && motion.changedRatio >= 0.001)
+      }
+    ]
+
+    console.log(`Cloth route check
+URL: ${url}
+State: ${state}
+Canvas count: ${canvasCount}
+Fallback visible: ${fallbackVisible}
+${motion ? `Changed ratio: ${motion.changedRatio.toFixed(4)}` : "Changed ratio: n/a"}
+
+Checks:`)
+
+    for (const check of checks) {
+      console.log(`  ${check.passed ? "pass" : "fail"} ${check.name}`)
+    }
+
+    if (pageErrors.length) console.log(`Page errors:\n${pageErrors.join("\n")}`)
+    if (consoleErrors.length) console.log(`Console errors:\n${consoleErrors.join("\n")}`)
+
+    if (!checks.every((check) => check.passed)) process.exitCode = 1
+  } finally {
+    if (browser) await browser.close()
+    await closeServer(server)
+  }
+}
+
+main().catch((error) => {
+  console.error(`check-cloth-route failed: ${error.message}`)
+  process.exit(1)
+})

--- a/react-three/src/App.js
+++ b/react-three/src/App.js
@@ -11,6 +11,7 @@ const inter = import("@pmndrs/assets/fonts/inter_regular.woff")
 
 // Lazy load turtle page (2MB model)
 const TurtlePage = lazy(() => import('./TurtlePage').then(m => ({ default: m.TurtleCanvas })))
+const WebGPUClothPage = lazy(() => import('./WebGPUClothPage').then(m => ({ default: m.WebGPUClothPage })))
 
 const mainSceneQuality = {
   mobile: {
@@ -33,6 +34,7 @@ export const App = () => {
   const [loc] = useLocation()
   const isAbout = loc === "/" || loc === "/about" || loc === "/about/"
   const isDemos = loc === "/demos" || loc === "/demos/"
+  const isCloth = loc === "/cloth" || loc === "/cloth/"
 
   if (isDemos) {
     return <DemosPage />
@@ -43,6 +45,10 @@ export const App = () => {
       {isAbout ? (
         <Suspense fallback={<div className="loading">Loading...</div>}>
           <TurtlePage />
+        </Suspense>
+      ) : isCloth ? (
+        <Suspense fallback={<div className="loading">Loading...</div>}>
+          <WebGPUClothPage />
         </Suspense>
       ) : (
         <MainCanvas />
@@ -169,12 +175,18 @@ const causeData = {
     title: "Enduring Hearts",
     description: "I serve on the board of Enduring Hearts, a pediatric heart transplant charity.",
     url: "https://www.enduringhearts.org/about-us/"
+  },
+  "/cloth": {
+    title: "WebGPU Cloth",
+    description: "Transparent compute-cloth study adapted from the Three.js WebGPU cloth demo.",
+    url: "https://threejs.org/examples/webgpu_compute_cloth.html"
   }
 }
 
 function CauseInfo() {
   const [loc] = useLocation()
-  const cause = causeData[loc] || causeData["/rights"]
+  const normalizedLoc = loc.endsWith("/") && loc.length > 1 ? loc.slice(0, -1) : loc
+  const cause = causeData[normalizedLoc] || causeData["/rights"]
   return (
     <div className="cause-info">
       <a href={cause.url} target="_blank" rel="noopener noreferrer">

--- a/react-three/src/App.test.js
+++ b/react-three/src/App.test.js
@@ -38,6 +38,10 @@ jest.mock("./TurtlePage", () => ({
   TurtleCanvas: () => <div data-testid="turtle-canvas" />
 }))
 
+jest.mock("./WebGPUClothPage", () => ({
+  WebGPUClothPage: () => <div data-testid="webgpu-cloth-page" />
+}), { virtual: true })
+
 jest.mock("wouter", () => ({
   Link: ({ children, to, className }) => (
     <a className={className} href={to}>{children}</a>
@@ -197,5 +201,32 @@ describe("App demos route", () => {
     expect(container.textContent).toContain("CSS3D Mixed")
     expect(container.textContent).toContain("WebGPU Compute Cloth")
     expect(container.querySelector(".nav")?.textContent || "").not.toContain("demos")
+  })
+})
+
+describe("App hidden cloth route", () => {
+  let container
+  let root
+
+  beforeEach(() => {
+    window.history.pushState({}, "", "/cloth")
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    window.history.pushState({}, "", "/")
+  })
+
+  it("renders the isolated WebGPU cloth page without adding it to the visible nav", async () => {
+    await act(async () => root.render(<App />))
+
+    expect(container.querySelector('[data-testid="webgpu-cloth-page"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="canvas"]')).toBeNull()
+    expect(container.textContent).toContain("WebGPU Cloth")
+    expect(container.querySelector(".nav")?.textContent || "").not.toContain("cloth")
   })
 })

--- a/react-three/src/WebGPUClothPage.js
+++ b/react-three/src/WebGPUClothPage.js
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from "react"
+import { createWebGPUClothScene } from "./webgpuClothScene"
+
+export function WebGPUClothPage() {
+  const stageRef = useRef(null)
+  const [state, setState] = useState("loading")
+
+  useEffect(() => {
+    const stage = stageRef.current
+
+    if (!stage || !navigator.gpu) {
+      setState("fallback")
+      return undefined
+    }
+
+    let disposed = false
+    let sceneHandle = null
+
+    createWebGPUClothScene(stage)
+      .then((handle) => {
+        if (disposed) {
+          handle.dispose()
+          return
+        }
+
+        sceneHandle = handle
+        setState("ready")
+      })
+      .catch(() => {
+        if (!disposed) setState("fallback")
+      })
+
+    return () => {
+      disposed = true
+      if (sceneHandle) sceneHandle.dispose()
+    }
+  }, [])
+
+  return (
+    <main className="cloth-page" data-webgpu-state={state}>
+      <div className="cloth-route-label">/cloth</div>
+      <div className="cloth-stage" data-testid="webgpu-cloth-stage" ref={stageRef} aria-hidden="true">
+        {state === "fallback" ? (
+          <div className="cloth-fallback-visual">
+            <div className="cloth-fallback-ball" />
+            <div className="cloth-fallback-sheet" />
+          </div>
+        ) : null}
+      </div>
+    </main>
+  )
+}

--- a/react-three/src/WebGPUClothPage.test.js
+++ b/react-three/src/WebGPUClothPage.test.js
@@ -1,0 +1,70 @@
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+import { WebGPUClothPage } from "./WebGPUClothPage"
+import { createWebGPUClothScene } from "./webgpuClothScene"
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+jest.mock("./webgpuClothScene", () => ({
+  createWebGPUClothScene: jest.fn()
+}), { virtual: true })
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe("WebGPUClothPage", () => {
+  let container
+  let root
+  let originalGpu
+
+  beforeEach(() => {
+    originalGpu = navigator.gpu
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    createWebGPUClothScene.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    Object.defineProperty(navigator, "gpu", {
+      configurable: true,
+      value: originalGpu
+    })
+  })
+
+  it("uses the graceful fallback when WebGPU is unavailable", async () => {
+    Object.defineProperty(navigator, "gpu", {
+      configurable: true,
+      value: undefined
+    })
+
+    await act(async () => root.render(<WebGPUClothPage />))
+
+    expect(createWebGPUClothScene).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-webgpu-state="fallback"]')).not.toBeNull()
+  })
+
+  it("mounts and disposes the WebGPU cloth scene when WebGPU is available", async () => {
+    const dispose = jest.fn()
+    createWebGPUClothScene.mockResolvedValue({ dispose })
+    Object.defineProperty(navigator, "gpu", {
+      configurable: true,
+      value: {}
+    })
+
+    await act(async () => {
+      root.render(<WebGPUClothPage />)
+      await flushPromises()
+    })
+
+    const stage = container.querySelector('[data-testid="webgpu-cloth-stage"]')
+    expect(stage).not.toBeNull()
+    expect(createWebGPUClothScene).toHaveBeenCalledWith(stage)
+
+    act(() => root.unmount())
+
+    expect(dispose).toHaveBeenCalled()
+  })
+})

--- a/react-three/src/styles.css
+++ b/react-three/src/styles.css
@@ -275,6 +275,79 @@ a:visited {
   padding: 12px 16px 16px 16px;
 }
 
+.cloth-page {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background: #e0e0e0;
+}
+
+.cloth-route-label {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  z-index: 0;
+  transform: translate(-50%, -50%);
+  color: #050505;
+  font-size: clamp(7rem, 18vw, 16rem);
+  font-weight: 500;
+  line-height: 0.85;
+  letter-spacing: 0;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.cloth-stage {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.cloth-webgpu-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.cloth-fallback-visual {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: min(52vw, 520px);
+  aspect-ratio: 1;
+  transform: translate(-50%, -50%);
+}
+
+.cloth-fallback-ball {
+  position: absolute;
+  inset: 17%;
+  border: 1px solid rgba(255, 255, 255, 0.74);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 34% 28%, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.16) 24%, rgba(255, 255, 255, 0.05) 58%, rgba(31, 95, 143, 0.16)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.26), rgba(31, 95, 143, 0.08));
+  box-shadow:
+    inset 22px 18px 60px rgba(255, 255, 255, 0.34),
+    inset -18px -14px 52px rgba(31, 95, 143, 0.22),
+    0 22px 80px rgba(31, 95, 143, 0.16);
+}
+
+.cloth-fallback-sheet {
+  position: absolute;
+  left: 7%;
+  right: 7%;
+  top: 25%;
+  height: 45%;
+  border-radius: 44% 56% 48% 52% / 42% 46% 54% 58%;
+  background:
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.24) 0 1px, transparent 1px 18px),
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.18) 0 1px, transparent 1px 18px),
+    linear-gradient(120deg, rgba(31, 95, 143, 0.55), rgba(151, 210, 238, 0.3));
+  filter: drop-shadow(0 20px 40px rgba(13, 68, 105, 0.18));
+  opacity: 0.78;
+  transform: rotate(-4deg);
+}
+
 /* Mobile responsive */
 @media (max-width: 768px) {
   .nav {
@@ -338,6 +411,14 @@ a:visited {
   .demo-card iframe {
     height: 360px;
   }
+
+  .cloth-route-label {
+    font-size: clamp(4.6rem, 23vw, 9rem);
+  }
+
+  .cloth-fallback-visual {
+    width: min(78vw, 420px);
+  }
 }
 
 @media (max-width: 480px) {
@@ -369,5 +450,9 @@ a:visited {
 
   .demo-card iframe {
     height: 320px;
+  }
+
+  .cloth-route-label {
+    font-size: clamp(3.8rem, 24vw, 7rem);
   }
 }

--- a/react-three/src/webgpuClothScene.js
+++ b/react-three/src/webgpuClothScene.js
@@ -1,0 +1,223 @@
+import * as THREE from "three-webgpu/webgpu"
+import {
+  cos,
+  float,
+  instanceIndex,
+  sin,
+  storage,
+  timerLocal,
+  tslFn,
+  uniform,
+  vec3
+} from "three-webgpu/tsl"
+
+const CLOTH_WIDTH = 2.45
+const CLOTH_HEIGHT = 1.65
+const CLOTH_SEGMENTS_X = 72
+const CLOTH_SEGMENTS_Y = 48
+const SPHERE_RADIUS = 0.68
+
+export async function createWebGPUClothScene(mount) {
+  const renderer = new THREE.WebGPURenderer({
+    alpha: true,
+    antialias: true,
+    powerPreference: "high-performance"
+  })
+
+  const scene = new THREE.Scene()
+  const camera = new THREE.PerspectiveCamera(38, 1, 0.01, 20)
+  camera.position.set(0, 0.02, 4.35)
+  camera.lookAt(0, -0.04, 0)
+
+  scene.add(new THREE.AmbientLight(0xffffff, 1.6))
+
+  const keyLight = new THREE.DirectionalLight(0xffffff, 3.2)
+  keyLight.position.set(2.8, 3.5, 3.2)
+  scene.add(keyLight)
+
+  const rimLight = new THREE.DirectionalLight(0x96d8ff, 1.4)
+  rimLight.position.set(-2.5, 1.4, -2.2)
+  scene.add(rimLight)
+
+  const clothMesh = createClothMesh()
+  scene.add(clothMesh.mesh)
+
+  const sphereCenter = uniform(new THREE.Vector3(0, -0.08, 0.04))
+  const sphere = createGlassSphere()
+  scene.add(sphere.group)
+
+  const computeCloth = createClothCompute(clothMesh, sphereCenter)
+
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5))
+  renderer.domElement.className = "cloth-webgpu-canvas"
+  renderer.domElement.dataset.motionProbe = "webgpu-cloth"
+
+  const resize = () => {
+    const rect = mount.getBoundingClientRect()
+    const width = Math.max(1, Math.floor(rect.width))
+    const height = Math.max(1, Math.floor(rect.height))
+
+    camera.aspect = width / height
+    camera.updateProjectionMatrix()
+    renderer.setSize(width, height)
+  }
+
+  resize()
+
+  await renderer.init()
+
+  mount.appendChild(renderer.domElement)
+
+  const resizeObserver = new ResizeObserver(resize)
+  resizeObserver.observe(mount)
+
+  let disposed = false
+  let frameInFlight = false
+
+  const render = async (now = 0) => {
+    if (disposed || frameInFlight) return
+
+    frameInFlight = true
+
+    try {
+      const seconds = now * 0.001
+      sphereCenter.value.set(Math.sin(seconds * 0.7) * 0.07, -0.08 + Math.sin(seconds * 0.45) * 0.025, 0.04)
+      sphere.group.position.copy(sphereCenter.value)
+      sphere.group.rotation.set(seconds * 0.18, seconds * 0.28, seconds * 0.12)
+
+      await renderer.computeAsync(computeCloth)
+      renderer.render(scene, camera)
+    } finally {
+      frameInFlight = false
+    }
+  }
+
+  await renderer.setAnimationLoop(render)
+
+  return {
+    dispose() {
+      disposed = true
+      resizeObserver.disconnect()
+      renderer.setAnimationLoop(null)
+
+      if (renderer.domElement.parentElement === mount) {
+        mount.removeChild(renderer.domElement)
+      }
+
+      clothMesh.geometry.dispose()
+      clothMesh.material.dispose()
+      sphere.geometry.dispose()
+      sphere.material.dispose()
+      sphere.ringGeometry.dispose()
+      sphere.ringMaterial.dispose()
+      renderer.dispose()
+    }
+  }
+}
+
+function createClothMesh() {
+  const geometry = new THREE.PlaneGeometry(CLOTH_WIDTH, CLOTH_HEIGHT, CLOTH_SEGMENTS_X, CLOTH_SEGMENTS_Y)
+  const basePosition = geometry.attributes.position.clone()
+  const baseNormal = geometry.attributes.normal.clone()
+  const positionStorage = new THREE.StorageBufferAttribute(basePosition.count, 4)
+  const normalStorage = new THREE.StorageBufferAttribute(baseNormal.count, 4)
+
+  geometry.setAttribute("position", positionStorage)
+  geometry.setAttribute("normal", normalStorage)
+
+  const material = new THREE.MeshStandardNodeMaterial({
+    color: 0x1f5f8f,
+    opacity: 0.62,
+    roughness: 0.3,
+    side: THREE.DoubleSide,
+    transparent: true
+  })
+  material.depthWrite = false
+
+  const mesh = new THREE.Mesh(geometry, material)
+  mesh.frustumCulled = false
+  mesh.position.set(0, 0.02, 0)
+
+  return {
+    baseNormal,
+    basePosition,
+    geometry,
+    material,
+    mesh,
+    normalStorage,
+    positionStorage
+  }
+}
+
+function createClothCompute(clothMesh, sphereCenter) {
+  const basePosition = storage(clothMesh.basePosition, "vec3", clothMesh.basePosition.count).toReadOnly()
+  const baseNormal = storage(clothMesh.baseNormal, "vec3", clothMesh.baseNormal.count).toReadOnly()
+  const positionStorage = storage(clothMesh.positionStorage, "vec4", clothMesh.positionStorage.count)
+  const normalStorage = storage(clothMesh.normalStorage, "vec4", clothMesh.normalStorage.count)
+  const sphereRadius = uniform(SPHERE_RADIUS)
+
+  const computeFn = tslFn(() => {
+    const base = vec3(basePosition.element(instanceIndex))
+    const normal = vec3(baseNormal.element(instanceIndex))
+    const time = timerLocal(0.85)
+
+    const fold = sin(base.x.mul(5.2).add(time.mul(2.4))).mul(0.075)
+      .add(cos(base.y.mul(6.5).sub(time.mul(1.35))).mul(0.045))
+    const sag = float(CLOTH_HEIGHT * 0.5).sub(base.y).mul(0.12)
+    const displaced = vec3(base.x, base.y.sub(sag).add(fold.mul(0.24)), base.z.add(fold)).toVar()
+
+    const sphereDelta = displaced.sub(sphereCenter)
+    const sphereDistance = sphereDelta.length().max(0.001)
+    const spherePush = sphereRadius.sub(sphereDistance).max(0).mul(0.9)
+
+    displaced.assign(displaced.add(sphereDelta.div(sphereDistance).mul(spherePush)))
+    positionStorage.element(instanceIndex).assign(displaced)
+    normalStorage.element(instanceIndex).assign(normal)
+  })
+
+  return computeFn().compute(clothMesh.basePosition.count)
+}
+
+function createGlassSphere() {
+  const geometry = new THREE.SphereGeometry(SPHERE_RADIUS, 64, 32)
+  const material = new THREE.MeshStandardNodeMaterial({
+    color: 0xf8fbff,
+    metalness: 0,
+    opacity: 0.28,
+    roughness: 0.04,
+    transparent: true
+  })
+  material.depthWrite = false
+
+  const group = new THREE.Group()
+  const sphere = new THREE.Mesh(geometry, material)
+  group.add(sphere)
+
+  const ringGeometry = new THREE.TorusGeometry(SPHERE_RADIUS * 1.01, 0.006, 10, 128)
+  const ringMaterial = new THREE.MeshBasicNodeMaterial({
+    color: 0xffffff,
+    opacity: 0.34,
+    transparent: true
+  })
+  ringMaterial.depthWrite = false
+
+  const rings = [
+    [0, 0, 0],
+    [Math.PI / 2, 0, 0],
+    [0, Math.PI / 2, 0]
+  ]
+
+  rings.forEach((rotation) => {
+    const ring = new THREE.Mesh(ringGeometry, ringMaterial)
+    ring.rotation.set(...rotation)
+    group.add(ring)
+  })
+
+  return {
+    geometry,
+    group,
+    material,
+    ringGeometry,
+    ringMaterial
+  }
+}


### PR DESCRIPTION
## Summary
- Added hidden `/cloth` and `/cloth/` routes using the existing cause-page overlay pattern without adding the route to visible nav.
- Added an isolated lazy-loaded WebGPU cloth scene using a `three-webgpu` npm alias so the existing app Three/Drei stack stays pinned.
- Added WebGPU fallback handling plus a Playwright verifier that checks the route, nav hiding, console/page errors, and automatic motion.

Closes #36

## Exit criterion
`npm run verify:cloth-route`

```text

> router-transitions@1.0.0 verify:cloth-route
> npm test -- --watchAll=false --silent && npm run build && node scripts/check-cloth-route.mjs


> router-transitions@1.0.0 test
> react-scripts test --env=jsdom --watchAll=false --silent

Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
PASS src/App.test.js
PASS src/WebGPUClothPage.test.js
PASS src/TurtlePage.test.js

Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        0.896 s, estimated 1 s

> router-transitions@1.0.0 build
> react-scripts build

Creating an optimized production build...
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Compiled with warnings.

Failed to parse source map from '/home/avi21/marketing/aviyashchinhomepage-wt-issue-36-cloth/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map' file: Error: ENOENT: no such file or directory, open '/home/avi21/marketing/aviyashchinhomepage-wt-issue-36-cloth/react-three/node_modules/@mediapipe/tasks-vision/vision_bundle_mjs.js.map'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  523.52 kB  build/static/js/main.b5c7d128.js
  165.31 kB  build/static/js/743.5e859ab1.chunk.js
  33.54 kB   build/static/js/771.e2f0600b.chunk.js
  12.99 kB   build/static/js/419.913e5443.chunk.js
  2.04 kB    build/static/js/855.d23acf1e.chunk.js
  1.85 kB    build/static/css/main.add8c54d.css
  1.38 kB    build/static/js/879.62293998.chunk.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  npm install -g serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

Cloth route check
URL: http://127.0.0.1:3126/cloth
State: ready
Canvas count: 1
Fallback visible: false
Changed ratio: 0.2256

Checks:
  pass cloth page reached terminal state
  pass cause overlay is present
  pass hidden route is not in nav
  pass no page errors
  pass no console errors
  pass visual is present
  pass ready scene has automatic motion

```

## Out of scope
- Did not iframe the Three.js example demos.
- Did not change existing `/rights`, `/activism`, `/charity`, or turtle visuals.
- Cut the direct `three` package upgrade because it broke the existing Drei import surface; used an isolated `three-webgpu` alias instead.

## Process note
- Phase 3 read-only parallel agents were skipped; investigation and implementation stayed in a dedicated worktree for issue #36.
